### PR TITLE
Exception Handler 설정

### DIFF
--- a/src/main/java/com/example/mssaem_backend/global/config/exception/BaseException.java
+++ b/src/main/java/com/example/mssaem_backend/global/config/exception/BaseException.java
@@ -1,0 +1,17 @@
+package com.example.mssaem_backend.global.config.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class BaseException extends RuntimeException {
+    private final String errorCode;
+    private final String message;
+    private final HttpStatus status;
+
+    public BaseException(ErrorCode code) {
+        errorCode = code.getErrorCode();
+        message = code.getMessage();
+        status = code.getStatus();
+    }
+}

--- a/src/main/java/com/example/mssaem_backend/global/config/exception/ControllerAdvice.java
+++ b/src/main/java/com/example/mssaem_backend/global/config/exception/ControllerAdvice.java
@@ -1,0 +1,92 @@
+package com.example.mssaem_backend.global.config.exception;
+
+import com.example.mssaem_backend.global.config.exception.errorCode.GlobalErrorCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import java.util.List;
+
+@RestControllerAdvice
+public class ControllerAdvice {
+
+    /**
+     * 미리 지정해놓은 에러 e 발생 시 ExceptionResponse 로 반환
+     */
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<ExceptionResponse> handleBaseException(BaseException e) {
+        return new ResponseEntity<>(new ExceptionResponse(e.getErrorCode(), e.getMessage()), e.getStatus());
+    }
+
+    /**
+     * CASE: 잘못된 URI 요청
+     */
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<ExceptionResponse> handleNoHandlerFoundException(
+            NoHandlerFoundException e) {
+        System.out.println(e);
+        return convert(GlobalErrorCode.NOT_SUPPORTED_URI_ERROR, HttpStatus.NOT_FOUND);
+    }
+
+    /**
+     * CASE: 잘못된 HTTP METHOD 요청
+     */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ExceptionResponse> handleMethodNotSupportedException(
+            HttpRequestMethodNotSupportedException e) {
+        System.out.println(e);
+        return convert(GlobalErrorCode.NOT_SUPPORTED_METHOD_ERROR, HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+    /**
+     * CASE: 잘못된 MEDIA TYPE 요청
+     */
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    public ResponseEntity<ExceptionResponse> handleMediaTypeNotSupportedException(
+            HttpMediaTypeNotSupportedException e) {
+        System.out.println(e);
+        return convert(GlobalErrorCode.NOT_SUPPORTED_MEDIA_TYPE_ERROR,
+                HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    /**
+     * CASE: 서버 내부 에러
+     */
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ExceptionResponse> handleRuntimeException(RuntimeException e) {
+        System.out.println(e);
+        return convert(GlobalErrorCode.SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * CASE: 잘못된 ARGUMENT 요청
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ExceptionResponse> handleException(MethodArgumentNotValidException e) {
+        System.out.println(e);
+        String detailMessage = extractMessage(e.getBindingResult().getFieldErrors());
+        return convert(GlobalErrorCode.NOT_VALID_ARGUMENT_ERROR, detailMessage);
+    }
+
+    private String extractMessage(List<FieldError> fieldErrors) {
+        StringBuilder builder = new StringBuilder();
+        fieldErrors.forEach((error) -> builder.append(error.getDefaultMessage()));
+        return builder.toString();
+    }
+
+    private ResponseEntity<ExceptionResponse> convert(ErrorCode e, HttpStatus httpStatus) {
+        return new ResponseEntity<>(new ExceptionResponse(e.getErrorCode(), e.getMessage()), httpStatus);
+    }
+
+    private ResponseEntity<ExceptionResponse> convert(ErrorCode e, String detailMessage) {
+        ExceptionResponse exceptionRes = new ExceptionResponse(e.getErrorCode(), detailMessage);
+        return new ResponseEntity<>(exceptionRes, HttpStatus.BAD_REQUEST);
+    }
+
+}

--- a/src/main/java/com/example/mssaem_backend/global/config/exception/ErrorCode.java
+++ b/src/main/java/com/example/mssaem_backend/global/config/exception/ErrorCode.java
@@ -1,0 +1,11 @@
+package com.example.mssaem_backend.global.config.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    String getErrorCode();
+
+    String getMessage();
+
+    HttpStatus getStatus();
+}

--- a/src/main/java/com/example/mssaem_backend/global/config/exception/ExceptionResponse.java
+++ b/src/main/java/com/example/mssaem_backend/global/config/exception/ExceptionResponse.java
@@ -1,0 +1,19 @@
+package com.example.mssaem_backend.global.config.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ExceptionResponse {
+    private final String code;
+    private final String message;
+    private final LocalDateTime timeStamp;
+
+    public ExceptionResponse(String code, String message) {
+        this.code = code;
+        this.message = message;
+        this.timeStamp = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/mssaem_backend/global/config/exception/errorCode/GlobalErrorCode.java
+++ b/src/main/java/com/example/mssaem_backend/global/config/exception/errorCode/GlobalErrorCode.java
@@ -1,0 +1,22 @@
+package com.example.mssaem_backend.global.config.exception.errorCode;
+
+import com.example.mssaem_backend.global.config.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum GlobalErrorCode implements ErrorCode {
+    NOT_VALID_ARGUMENT_ERROR("GLOBAL_001", "올바른 argument를 입력해주세요.", HttpStatus.BAD_REQUEST),
+    NOT_SUPPORTED_URI_ERROR("GLOBAL_002", "올바른 URI로 접근해주세요.", HttpStatus.NOT_FOUND),
+    NOT_SUPPORTED_METHOD_ERROR("GLOBAL_003", "지원하지 않는 Method입니다.", HttpStatus.METHOD_NOT_ALLOWED),
+    NOT_SUPPORTED_MEDIA_TYPE_ERROR("GLOBAL_004", "지원하지 않는 Media type입니다.", HttpStatus.UNSUPPORTED_MEDIA_TYPE),
+    SERVER_ERROR("GLOBAL_005", "서버와의 연결에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    ACCESS_DENIED("GLOBAL_006", "권한이 없습니다.", HttpStatus.FORBIDDEN),
+    ;
+
+    private final String errorCode;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/example/mssaem_backend/global/config/exception/errorCode/MemberErrorCode.java
+++ b/src/main/java/com/example/mssaem_backend/global/config/exception/errorCode/MemberErrorCode.java
@@ -1,0 +1,17 @@
+package com.example.mssaem_backend.global.config.exception.errorCode;
+
+import com.example.mssaem_backend.global.config.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MemberErrorCode implements ErrorCode {
+    EMPTY_MEMBER("MEMBER_001", "존재하지 않는 사용자입니다.", HttpStatus.CONFLICT)
+    ;
+
+    private final String errorCode;
+    private final String message;
+    private final HttpStatus status;
+}


### PR DESCRIPTION
## 요약

- 에러 핸들링 설정

## 상세 내용

- `BaseException` 는 java의 `RuntimeException` 를 상속받는 기본 에러 class
- `ExceptionResponse`는 에러 발생 시 에러 내용 내려줄 때 사용하는 응답 형식
- `ControllerAdvice`는 `ExceptionHandler`와 비슷한 역할을 하는데, 특정 클래스에 대한 에러를 다루는 `ExceptionHandler`과는 달리 전역에서 발생한 에러를 관리
- `ErrorCode`는 에러 커스텀을 위해 만들어 놓은 인터페이스

## 질문 및 이외 사항

- 우리는 이제 도메인 별로 나눠서 에러를 커스텀 할 것입니다.
- `BoardErrorCode` 와 같이 만들고 `ErrorCode` 인터페이스를 상속받아, 에러를 커스텀하여 사용하시면 됩니다.
- API 명세서를 통해 프론트에게 전달할 때 에러에 대해 정확히 명시해야합니다!!! 
- 참고: https://jeong-pro.tistory.com/195

## 이슈 번호

-