### PR TITLE
홈 화면 조회 - HOT 게시판 API 

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardController.java
@@ -16,7 +16,13 @@ public class BoardController {
     private final BoardService boardService;
 
     @GetMapping("/boards/hot")
-    public ResponseEntity<PageResponseDto<List<BoardSimpleInfo>>> findHotBoardList(@RequestParam int page, @RequestParam int size) {
+    public ResponseEntity<PageResponseDto<List<BoardSimpleInfo>>> findHotBoardList(
+        @RequestParam int page, @RequestParam int size) {
         return ResponseEntity.ok(boardService.findHotBoardList(page, size));
+    }
+
+    @GetMapping("/boards/home")
+    public ResponseEntity<List<BoardSimpleInfo>> findHotBoardListForHome() {
+        return ResponseEntity.ok(boardService.findHotBoardListForHome());
     }
 }

--- a/src/test/java/com/example/mssaem_backend/domain/evaluation/EvaluationControllerTest.java
+++ b/src/test/java/com/example/mssaem_backend/domain/evaluation/EvaluationControllerTest.java
@@ -1,4 +1,4 @@
-package com.example.mssaem_backend.domain.evaluation;
+/*package com.example.mssaem_backend.domain.evaluation;
 
 import com.example.mssaem_backend.domain.evaluation.dto.EvaluationRequestDto.EvaluationInfo;
 import com.example.mssaem_backend.domain.mbti.MbtiEnum;
@@ -135,4 +135,4 @@ class EvaluationControllerTest {
 
 
 
-}
+}*/

--- a/src/test/java/com/example/mssaem_backend/domain/evaluation/EvaluationControllerTest.java
+++ b/src/test/java/com/example/mssaem_backend/domain/evaluation/EvaluationControllerTest.java
@@ -1,4 +1,4 @@
-/*package com.example.mssaem_backend.domain.evaluation;
+package com.example.mssaem_backend.domain.evaluation;
 
 import com.example.mssaem_backend.domain.evaluation.dto.EvaluationRequestDto.EvaluationInfo;
 import com.example.mssaem_backend.domain.mbti.MbtiEnum;
@@ -135,4 +135,4 @@ class EvaluationControllerTest {
 
 
 
-}*/
+}


### PR DESCRIPTION
## 요약

- 홈 화면에 3일 동안 10개 이상의 좋아요를 받은 게시물 중 3일 동안 받은 좋아요수를 기준으로 내림차순 정렬했을 때 최상위 게시물을 제외한 상위 4개의 게시물 조회

## 상세 내용
#### BoardController
``` java
    @GetMapping("/boards/home")
    public ResponseEntity<List<BoardSimpleInfo>> findHotBoardListForHome() {
        return ResponseEntity.ok(boardService.findHotBoardListForHome());
    }
```
#### BoardService
``` java
 public List<BoardSimpleInfo> findHotBoardListForHome() {
        PageRequest pageRequest = PageRequest.of(0, 5);
        List<Board> boards =
            likeRepository.findBoardsWithMoreThanTenLikesInLastThreeDays(
                    LocalDateTime.now().minusDays(3)
                    , pageRequest
                )
                .stream()
                .collect(Collectors.toList());
        if (!boards.isEmpty()) {
            boards.remove(0);
        }

        return setBoardSimpleInfo(boards);
    }
```
- `likeRepository.findBoardsWithMoreThanTenLikesInLastThreeDays`에 page는 0이고, size는 5인 pageRequest를 넘겨줘 JPQL에서 사용하지 못하는 LIMIT과 같은 기능을 하게 함
- Query문에서 최상위 게시물을 제외하는건 복잡해서 일단 상위 5개를 받아와 List로 바꿔주고 List의 첫번째 index에 해당하는 데이터를 지움
- `setBoardSimpleInfo` 메소드의 경우 파라미터를 Page -> List로 바꿔주어 재사용성을 높임 
## 질문 및 이외 사항

❓PR API 하나씩 올리는게 습관이라 #21 이슈에 해당하는 API 하나로만 올렸는데 괜찮을까요?
❗️좀 더 간결하게 만들 수 있을 거 같은 부분 지적 부탁드립니다!

## 이슈 번호

- #21
