### PR TITLE
홈 화면 조회 - HOT 토론 API

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionController.java
@@ -17,9 +17,21 @@ public class DiscussionController {
 
     private final DiscussionService discussionService;
 
+    /**
+     * HOT 토론 더보기
+     */
     @GetMapping("/discussions/hot")
     public ResponseEntity<PageResponseDto<List<DiscussionSimpleInfo>>> findHotDiscussionList(
         @CurrentMember Member member, @RequestParam int page, @RequestParam int size) {
         return ResponseEntity.ok(discussionService.findHotDiscussionList(member, page, size));
+    }
+
+    /**
+     * 홈 화면 조회 - HOT 토론 2개
+     */
+    @GetMapping("/discussions/home")
+    public ResponseEntity<List<DiscussionSimpleInfo>> findHotDiscussionListForHome(
+        @CurrentMember Member member) {
+        return ResponseEntity.ok(discussionService.findHotDiscussionListForHome(member));
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionService.java
@@ -32,6 +32,7 @@ public class DiscussionService {
     private final DiscussionCommentRepository discussionCommentRepository;
     private final BadgeRepository badgeRepository;
 
+    // HOT 토론글 전체 조회
     public PageResponseDto<List<DiscussionSimpleInfo>> findHotDiscussionList(Member member,
         int page, int size) {
         PageRequest pageRequest = PageRequest.of(page, size);
@@ -48,6 +49,22 @@ public class DiscussionService {
                     .stream()
                     .collect(Collectors.toList()))
         );
+    }
+
+    // 최상위 제외한 HOT 토론글 2개만 조회
+    public List<DiscussionSimpleInfo> findHotDiscussionListForHome(Member member) {
+        PageRequest pageRequest = PageRequest.of(0, 3);
+        List<Discussion> discussions = discussionRepository.findDiscussionWithMoreThanTenParticipantsInLastThreeDays(
+                LocalDateTime.now().minusDays(3)
+                , pageRequest)
+            .stream()
+            .collect(Collectors.toList());
+
+        if (!discussions.isEmpty()) {
+            discussions.remove(0);
+        }
+
+        return setDiscussionSimpleInfo(member, discussions);
     }
 
     // 토론글의 정보를 Dto에 매핑하는 메소드

--- a/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionService.java
@@ -54,7 +54,7 @@ public class DiscussionService {
     // 최상위 제외한 HOT 토론글 2개만 조회
     public List<DiscussionSimpleInfo> findHotDiscussionListForHome(Member member) {
         PageRequest pageRequest = PageRequest.of(0, 3);
-        List<Discussion> discussions = discussionRepository.findDiscussionWithMoreThanTenParticipantsInLastThreeDays(
+        List<Discussion> discussions = discussionRepository.findDiscussionWithMoreThanTenParticipantsInLastThreeDaysAndStateTrue(
                 LocalDateTime.now().minusDays(3)
                 , pageRequest)
             .stream()


### PR DESCRIPTION
## 요약

- 홈 화면에 보여줄 최상위 토론글을 제외한 HOT 토론 2개를 조회

## 상세 내용
#### DiscussionController
``` java
    /**
     * 홈 화면 조회 - HOT 토론 2개
     */
    @GetMapping("/discussions/home")
    public ResponseEntity<List<DiscussionSimpleInfo>> findHotDiscussionListForHome(
        @CurrentMember Member member) {
        return ResponseEntity.ok(discussionService.findHotDiscussionListForHome(member));
    }
```
#### DiscussionService
```java
    public List<DiscussionSimpleInfo> findHotDiscussionListForHome(Member member) {
        PageRequest pageRequest = PageRequest.of(0, 3);
        List<Discussion> discussions = discussionRepository.findDiscussionWithMoreThanTenParticipantsInLastThreeDays(
                LocalDateTime.now().minusDays(3)
                , pageRequest)
            .stream()
            .collect(Collectors.toList());

        if (!discussions.isEmpty()) {
            discussions.remove(0);
        }

        return setDiscussionSimpleInfo(member, discussions);
    }
```
- 생성된지 3일 이내이고, 참여자수가 10명 이상인 토론글 중 상위 3개만 조회해오기 위해 PageRequest.of(0,3)으로 개수 제한
- 조회해온 discussions가 비어있지 않다면, 즉 1개 이상이라면 가장 첫번째(최상위 토론글) 객체를 삭제 
- `setDiscussionSimpleInfo`로 로그인 여부까지 고려해 토론글 정보 Dto에 매핑
## 질문 및 이외 사항

❗️HOT 토론 더보기 기능과 마찬가지로 참여자수 10명 이상이라는 기준을 테스트를 위해 1명 이상으로 변경했습니다. 추후에 수정하겠습니다! 

## 이슈 번호

- #60
