### PR TITLE
홈 화면 조회 - M쌤 매칭을 기다리는 고민 API 

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
@@ -38,6 +38,7 @@ public class BoardService {
     private final BadgeRepository badgeRepository;
     private final BoardImageRepository boardImageRepository;
 
+    // HOT 게시물 더보기
     public PageResponseDto<List<BoardSimpleInfo>> findHotBoardList(int page, int size) {
         PageRequest pageRequest = PageRequest.of(page, size);
         Page<Board> boards =
@@ -52,7 +53,8 @@ public class BoardService {
             setBoardSimpleInfo(
                 boards
                     .stream()
-                    .collect(Collectors.toList()))
+                    .collect(Collectors.toList()),
+                1)
         );
     }
 
@@ -69,10 +71,12 @@ public class BoardService {
             boards.remove(0);
         }
 
-        return setBoardSimpleInfo(boards);
+        return setBoardSimpleInfo(boards, 1);
     }
 
-    private List<BoardSimpleInfo> setBoardSimpleInfo(List<Board> boards) {
+
+    // 게시물 전체 조회시 각 게시물의 간단한 정보 Dto에 매핑
+    private List<BoardSimpleInfo> setBoardSimpleInfo(List<Board> boards, int dateType) {
         List<BoardSimpleInfo> boardSimpleInfos = new ArrayList<>();
 
         for (Board board : boards) {
@@ -86,7 +90,7 @@ public class BoardService {
                     board.getMbti(),
                     board.getLikeCount(),
                     boardCommentRepository.countWithStateTrueByBoard(board),
-                    Time.calculateTime(board.getCreatedAt(), 3),
+                    Time.calculateTime(board.getCreatedAt(), dateType),
                     new MemberSimpleInfo(
                         board.getMember().getId(),
                         board.getMember().getNickName(),

--- a/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionService.java
@@ -47,7 +47,8 @@ public class DiscussionService {
                 member,
                 discussions
                     .stream()
-                    .collect(Collectors.toList()))
+                    .collect(Collectors.toList()),
+                1)
         );
     }
 
@@ -64,12 +65,12 @@ public class DiscussionService {
             discussions.remove(0);
         }
 
-        return setDiscussionSimpleInfo(member, discussions);
+        return setDiscussionSimpleInfo(member, discussions, 1);
     }
 
     // 토론글의 정보를 Dto에 매핑하는 메소드
     private List<DiscussionSimpleInfo> setDiscussionSimpleInfo(Member member,
-        List<Discussion> discussions) {
+        List<Discussion> discussions, int dateType) {
         List<DiscussionSimpleInfo> discussionSimpleInfos = new ArrayList<>();
 
         int selectedOptionIdx = -1;
@@ -91,7 +92,7 @@ public class DiscussionService {
                     discussion.getContent(),
                     discussion.getParticipantCount(),
                     discussionCommentRepository.countWithStateTrueByDiscussion(discussion),
-                    Time.calculateTime(discussion.getCreatedAt(), 3),
+                    Time.calculateTime(discussion.getCreatedAt(), dateType),
                     new MemberSimpleInfo(
                         discussion.getMember().getId(),
                         discussion.getMember().getNickName(),

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardController.java
@@ -24,43 +24,59 @@ public class WorryBoardController {
 
     //고민글 조회 (해결 X)
     @GetMapping("/worry-board/waiting")
-    public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findWorriesWaiting(@RequestParam int page, @RequestParam int size) {
+    public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findWorriesWaiting(
+        @RequestParam int page, @RequestParam int size) {
         return ResponseEntity.ok(worryBoardService.findWorriesByState(false, page, size));
     }
 
     //고민글 조회 (해결 O)
     @GetMapping("/worry-board/solved")
-    public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findWorriesSolved(@RequestParam int page, @RequestParam int size) {
+    public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findWorriesSolved(
+        @RequestParam int page, @RequestParam int size) {
         return ResponseEntity.ok(worryBoardService.findWorriesByState(true, page, size));
     }
 
     //고민글 상세 조회
     @GetMapping("/worry-board/{id}")
-    public ResponseEntity<GetWorryRes> findWorryById(@CurrentMember Member viewer,@PathVariable Long id) {
+    public ResponseEntity<GetWorryRes> findWorryById(@CurrentMember Member viewer,
+        @PathVariable Long id) {
         return ResponseEntity.ok(worryBoardService.findWorryById(viewer, id));
     }
 
     //특정 멤버별 올린 고민글 조회
     @GetMapping("/worry-board/post-list")
-    public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findWorriesByMemberId(@RequestParam Long memberId, @RequestParam int page, @RequestParam int size) {
+    public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findWorriesByMemberId(
+        @RequestParam Long memberId, @RequestParam int page, @RequestParam int size) {
         return ResponseEntity.ok(worryBoardService.findWorriesByMemberId(memberId, page, size));
     }
 
     //특정 멤버별 해결한 고민글 조회
     @GetMapping("/worry-board/solve-list")
-    public ResponseEntity<PageResponseDto<List<GetWorriesRes>>>findSolveWorriesByMemberId(@RequestParam Long memberId, @RequestParam int page, @RequestParam int size) {
-        return ResponseEntity.ok(worryBoardService.findSolveWorriesByMemberId(memberId, page, size));
+    public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findSolveWorriesByMemberId(
+        @RequestParam Long memberId, @RequestParam int page, @RequestParam int size) {
+        return ResponseEntity.ok(
+            worryBoardService.findSolveWorriesByMemberId(memberId, page, size));
     }
 
     //고민 게시판(해결 X) - mbti별 고민글 조회
     @PostMapping("worry-board/waiting/filter")
-    public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findWaitingWorriesByMbti(@RequestBody GetWorriesReq getWorriesReq, @RequestParam int page, @RequestParam int size) {
-        return ResponseEntity.ok(worryBoardService.findWorriesByMbti(getWorriesReq, false, page, size));
+    public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findWaitingWorriesByMbti(
+        @RequestBody GetWorriesReq getWorriesReq, @RequestParam int page, @RequestParam int size) {
+        return ResponseEntity.ok(
+            worryBoardService.findWorriesByMbti(getWorriesReq, false, page, size));
     }
 
     //고민 게시판(해결 O) - mbti별 고민글 조회
     @PostMapping("worry-board/solved/filter")
-    public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findSolvedWorriesByMbti(@RequestBody GetWorriesReq getWorriesReq, @RequestParam int page, @RequestParam int size) {
-        return ResponseEntity.ok(worryBoardService.findWorriesByMbti(getWorriesReq, true, page, size));
+    public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findSolvedWorriesByMbti(
+        @RequestBody GetWorriesReq getWorriesReq, @RequestParam int page, @RequestParam int size) {
+        return ResponseEntity.ok(
+            worryBoardService.findWorriesByMbti(getWorriesReq, true, page, size));
+    }
+
+    //홈 화면 조회 - 고민글 6개 조회 (해결 X, 최신순)
+    @GetMapping("/worry-board/home")
+    public ResponseEntity<List<GetWorriesRes>> findWaitingWorriesForHome() {
+        return ResponseEntity.ok(worryBoardService.findWorriesForHome());
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardRepository.java
@@ -1,6 +1,7 @@
 package com.example.mssaem_backend.domain.worryboard;
 
 import com.example.mssaem_backend.domain.mbti.MbtiEnum;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,6 +15,8 @@ public interface WorryBoardRepository extends JpaRepository<WorryBoard, Long> {
     Page<WorryBoard> findByMemberId(Long memberId, Pageable pageable);
 
     Page<WorryBoard> findBySolveMemberId(Long memberId, Pageable pageable);
+
+    List<WorryBoard> findTop7ByStateFalseOrderByCreatedAtDesc();
 
     @Query("SELECT wb FROM WorryBoard wb WHERE wb.state = :state AND (:fromMbti IS NULL OR wb.member.mbti = :fromMbti) AND (:toMbti IS NULL OR wb.targetMbti = :toMbti)")
     Page<WorryBoard> findWorriesByStateAndBothMbti(

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
@@ -105,9 +105,27 @@ public class WorryBoardService {
         MbtiEnum fromMbti = isFromAll ? null : MbtiEnum.valueOf(getWorriesReq.getFromMbti());
         MbtiEnum toMbti = isToAll ? null : MbtiEnum.valueOf(getWorriesReq.getToMbti());
 
-        Page<WorryBoard> result = worryBoardRepository.findWorriesByStateAndBothMbti(isSolved, fromMbti, toMbti, pageable);
+        Page<WorryBoard> result = worryBoardRepository.findWorriesByStateAndBothMbti(isSolved,
+            fromMbti, toMbti, pageable);
 
         return new PageResponseDto<>(result.getNumber(), result.getTotalPages(),
             makeGetWorriesResForm(result));
+    }
+
+    // 홈 화면에 보여줄 해결안된 고민글 최신순으로 조회
+    public List<GetWorriesRes> findWorriesForHome() {
+        List<WorryBoard> worryBoards = worryBoardRepository.findTop7ByStateFalseOrderByCreatedAtDesc();
+        if (!worryBoards.isEmpty()) {
+            worryBoards.remove(0);
+            System.out.println("최상위 1개 삭제 완료");
+        }
+
+        return worryBoards.stream()
+            .map(worryBoard -> GetWorriesRes.builder()
+                .worryBoard(worryBoard)
+                .imgUrl(worryBoardImageService.getImgUrl(worryBoard))
+                .createdAt(calculateTime(worryBoard.getCreatedAt(), 3))
+                .build())
+            .toList();
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
@@ -123,7 +123,7 @@ public class WorryBoardService {
             .map(worryBoard -> GetWorriesRes.builder()
                 .worryBoard(worryBoard)
                 .imgUrl(worryBoardImageService.getImgUrl(worryBoard))
-                .createdAt(calculateTime(worryBoard.getCreatedAt(), 3))
+                .createdAt(calculateTime(worryBoard.getCreatedAt(), 1))
                 .build())
             .toList();
     }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
@@ -117,7 +117,6 @@ public class WorryBoardService {
         List<WorryBoard> worryBoards = worryBoardRepository.findTop7ByStateFalseOrderByCreatedAtDesc();
         if (!worryBoards.isEmpty()) {
             worryBoards.remove(0);
-            System.out.println("최상위 1개 삭제 완료");
         }
 
         return worryBoards.stream()

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/dto/WorryBoardResponseDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/dto/WorryBoardResponseDto.java
@@ -12,55 +12,58 @@ import lombok.NoArgsConstructor;
 
 public class WorryBoardResponseDto {
 
-  @Getter
-  @NoArgsConstructor
-  @AllArgsConstructor
-  public static class GetWorryRes {
-    private MemberSimpleInfo memberSimpleInfo;
-    private Long worryBoardId;
-    private MbtiEnum targetMbti;
-    private String title;
-    private String content;
-    private String createdAt;
-    private List<String> imgList;
-    private Boolean isAllowed;
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetWorryRes {
 
-    @Builder
-    public GetWorryRes(WorryBoard worryBoard, List<String> imgList,
-        MemberSimpleInfo memberSimpleInfo, String createdAt, Boolean isAllowed) {
-      this.worryBoardId = worryBoard.getId();
-      this.memberSimpleInfo = memberSimpleInfo;
-      this.targetMbti = worryBoard.getTargetMbti();
-      this.title = worryBoard.getTitle();
-      this.content = worryBoard.getContent();
-      this.createdAt = createdAt;
-      this.imgList = imgList;
-      this.isAllowed = isAllowed;
+        private MemberSimpleInfo memberSimpleInfo;
+        private Long worryBoardId;
+        private MbtiEnum targetMbti;
+        private String title;
+        private String content;
+        private String createdAt;
+        private List<String> imgList;
+        private Boolean isAllowed;
+
+        @Builder
+        public GetWorryRes(WorryBoard worryBoard, List<String> imgList,
+            MemberSimpleInfo memberSimpleInfo, String createdAt, Boolean isAllowed) {
+            this.worryBoardId = worryBoard.getId();
+            this.memberSimpleInfo = memberSimpleInfo;
+            this.targetMbti = worryBoard.getTargetMbti();
+            this.title = worryBoard.getTitle();
+            this.content = worryBoard.getContent();
+            this.createdAt = createdAt;
+            this.imgList = imgList;
+            this.isAllowed = isAllowed;
+        }
     }
-  }
 
-  @Getter
-  @AllArgsConstructor
-  @NoArgsConstructor
-  public static class GetWorriesRes {
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class GetWorriesRes {
 
-    private String title;
-    private String content;
-    private MbtiEnum memberMbti;
-    private MbtiEnum targetMbti;
-    private String createdDate;
-    private String imgUrl;
+        private Long id;
+        private String title;
+        private String content;
+        private MbtiEnum memberMbti;
+        private MbtiEnum targetMbti;
+        private String createdDate;
+        private String imgUrl;
 
-    @Builder
-    public GetWorriesRes(WorryBoard worryBoard, String imgUrl, String createdAt) {
-      this.title = worryBoard.getTitle();
-      this.content = worryBoard.getContent();
-      this.memberMbti = worryBoard.getMember().getMbti();
-      this.targetMbti = worryBoard.getTargetMbti();
-      this.createdDate = createdAt;
-      this.imgUrl = imgUrl;
+        @Builder
+        public GetWorriesRes(WorryBoard worryBoard, String imgUrl, String createdAt) {
+            this.id = worryBoard.getId();
+            this.title = worryBoard.getTitle();
+            this.content = worryBoard.getContent();
+            this.memberMbti = worryBoard.getMember().getMbti();
+            this.targetMbti = worryBoard.getTargetMbti();
+            this.createdDate = createdAt;
+            this.imgUrl = imgUrl;
+        }
     }
-  }
 
 }
 


### PR DESCRIPTION
## 요약

- 홈 화면에 보여줄 M쌤 매칭을 기다리는 고민으로, 해결되지 않은 고민글을 생성일을 기준으로 내림차순 정렬했을 때 가장 최신 고민글 1개를 제외한 나머지 상위 6개 조회

## 상세 내용
#### WorryBoardController
```java
    //홈 화면 조회 - 고민글 6개 조회 (해결 X, 최신순)
    @GetMapping("/worry-board/home")
    public ResponseEntity<List<GetWorriesRes>> findWaitingWorriesForHome() {
        return ResponseEntity.ok(worryBoardService.findWorriesForHome());
    }
```
#### WorryBoardRepository
```java
    List<WorryBoard> findTop7ByStateFalseOrderByCreatedAtDesc();
````
- 생성일을 기준으로 내림차순 정렬했을 때 state가 false인 고민글 상위 7개 조회
#### WorryBoardService
``` java
    // 홈 화면에 보여줄 해결안된 고민글 최신순으로 조회
    public List<GetWorriesRes> findWorriesForHome() {
        List<WorryBoard> worryBoards = worryBoardRepository.findTop7ByStateFalseOrderByCreatedAtDesc();
        if (!worryBoards.isEmpty()) {
            worryBoards.remove(0);
        }


        return worryBoards.stream()
            .map(worryBoard -> GetWorriesRes.builder()
                .worryBoard(worryBoard)
                .imgUrl(worryBoardImageService.getImgUrl(worryBoard))
                .createdAt(calculateTime(worryBoard.getCreatedAt(), 3))
                .build())
            .toList();
    }
}
```
- 조회해온 상위 7개 고민글 중 최상위 1개 삭제 후 Dto에 매핑
- 해결 안된 고민글이 없는 경우 null로 처리됨 
#### WorryBoardResponseDto
- GetWorriesRes에 id 변수 추가 

## 질문 및 이외 사항
@gourderased
1. JPA 메소드에 ByStateTrue로 boolean 값을 직접 주지 않고도 해결 가능합니다! 필요하다고 생각하면 수정해주세요~!
2. 고민글 조회시 생성일 기준으로 Desc 정렬 필요할거 같아요.
3. makeGetWorriesResForm 메소드의 파라미터 타입이 Page<> 던데 홈 화면 관련 로직에서도 재사용할 수 있게 파라미터 타입을 List<>로 변경하고 싶은데 어떻게 생각하시나요? 

## 이슈 번호

- #67
