### PR TITLE
게시글 조회 관련 API , 카테고리 즐겨찾기 관련 API

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardController.java
@@ -3,6 +3,7 @@ package com.example.mssaem_backend.domain.board;
 import com.example.mssaem_backend.domain.board.dto.BoardRequestDto.PatchBoardReq;
 import com.example.mssaem_backend.domain.board.dto.BoardRequestDto.PostBoardReq;
 import com.example.mssaem_backend.domain.board.dto.BoardResponseDto.BoardSimpleInfo;
+import com.example.mssaem_backend.domain.board.dto.BoardResponseDto.GetBoardRes;
 import com.example.mssaem_backend.domain.mbti.MbtiEnum;
 import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.global.common.dto.PageResponseDto;
@@ -78,15 +79,29 @@ public class BoardController {
     /**
      * Mbti 카테고리 별 게시글 전체 조회
      */
-    @GetMapping("/board/{mbti}")
+    @GetMapping("/board/mbti/{mbti}")
     public ResponseEntity<PageResponseDto<List<BoardSimpleInfo>>> findBoardsByMbti(
-        @RequestParam(required = false) MbtiEnum mbti, @RequestParam int page, @RequestParam int size) {
-        return ResponseEntity.ok(boardService.findBoardsByMbti(mbti,page,size));
+        @RequestParam(required = false) MbtiEnum mbti, @RequestParam int page,
+        @RequestParam int size) {
+        return ResponseEntity.ok(boardService.findBoardsByMbti(mbti, page, size));
     }
 
-    @GetMapping("/board/{id}")
+    /**
+     * 특정 멤버별 게시글 전체 조회
+     */
+    @GetMapping("/board/member/{memberId}")
     public ResponseEntity<PageResponseDto<List<BoardSimpleInfo>>> findBoardsById(
         @RequestParam Long memberId, @RequestParam int page, @RequestParam int size) {
         return ResponseEntity.ok(boardService.findBoardsByMemberId(memberId, page, size));
     }
+
+    /**
+     * 게시글 상세조회
+     */
+    @GetMapping("/board/{boardId}")
+    public ResponseEntity<GetBoardRes> findBoardById(@CurrentMember Member viewer,
+        @PathVariable Long boardId) {
+        return ResponseEntity.ok(boardService.findBoardById(viewer, boardId));
+    }
+
 }

--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardController.java
@@ -72,8 +72,8 @@ public class BoardController {
      */
     @GetMapping("/board")
     public ResponseEntity<PageResponseDto<List<BoardSimpleInfo>>> findBoards(@RequestParam int page,
-        @RequestParam int size) {
-        return ResponseEntity.ok(boardService.findBoards(page, size));
+        @RequestParam int size, @RequestParam(required = false) Long boardId) {
+        return ResponseEntity.ok(boardService.findBoards(page, size, boardId));
     }
 
     /**

--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardController.java
@@ -64,4 +64,14 @@ public class BoardController {
     public ResponseEntity<String> deleteBoard(@CurrentMember Member member, @PathVariable Long id) {
         return ResponseEntity.ok(boardService.deleteBoard(member, id));
     }
+
+    /**
+     * 게시글 전체 조회
+     */
+    @GetMapping("/board")
+    public ResponseEntity<PageResponseDto<List<BoardSimpleInfo>>> findBoards(@RequestParam int page,
+        @RequestParam int size) {
+        return ResponseEntity.ok(boardService.findBoards(page, size));
+    }
+
 }

--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardController.java
@@ -80,7 +80,13 @@ public class BoardController {
      */
     @GetMapping("/board/{mbti}")
     public ResponseEntity<PageResponseDto<List<BoardSimpleInfo>>> findBoardsByMbti(
-        @RequestParam MbtiEnum mbti, @RequestParam int page, @RequestParam int size) {
+        @RequestParam(required = false) MbtiEnum mbti, @RequestParam int page, @RequestParam int size) {
         return ResponseEntity.ok(boardService.findBoardsByMbti(mbti,page,size));
+    }
+
+    @GetMapping("/board/{id}")
+    public ResponseEntity<PageResponseDto<List<BoardSimpleInfo>>> findBoardsById(
+        @RequestParam Long memberId, @RequestParam int page, @RequestParam int size) {
+        return ResponseEntity.ok(boardService.findBoardsByMemberId(memberId, page, size));
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardController.java
@@ -3,6 +3,7 @@ package com.example.mssaem_backend.domain.board;
 import com.example.mssaem_backend.domain.board.dto.BoardRequestDto.PatchBoardReq;
 import com.example.mssaem_backend.domain.board.dto.BoardRequestDto.PostBoardReq;
 import com.example.mssaem_backend.domain.board.dto.BoardResponseDto.BoardSimpleInfo;
+import com.example.mssaem_backend.domain.mbti.MbtiEnum;
 import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.global.common.dto.PageResponseDto;
 import com.example.mssaem_backend.global.config.security.auth.CurrentMember;
@@ -74,4 +75,12 @@ public class BoardController {
         return ResponseEntity.ok(boardService.findBoards(page, size));
     }
 
+    /**
+     * Mbti 카테고리 별 게시글 전체 조회
+     */
+    @GetMapping("/board/{mbti}")
+    public ResponseEntity<PageResponseDto<List<BoardSimpleInfo>>> findBoardsByMbti(
+        @RequestParam MbtiEnum mbti, @RequestParam int page, @RequestParam int size) {
+        return ResponseEntity.ok(boardService.findBoardsByMbti(mbti,page,size));
+    }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardRepository.java
@@ -1,6 +1,10 @@
 package com.example.mssaem_backend.domain.board;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
+
+    Page<Board> findAllByStateIsTrue(Pageable pageable);
 }

--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardRepository.java
@@ -1,5 +1,6 @@
 package com.example.mssaem_backend.domain.board;
 
+import com.example.mssaem_backend.domain.mbti.MbtiEnum;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
     Page<Board> findAllByStateIsTrue(Pageable pageable);
+
+    Page<Board> findAllByStateIsTrueAndMbti(MbtiEnum mbtiEnum, Pageable pageable);
 }

--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardRepository.java
@@ -10,4 +10,6 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     Page<Board> findAllByStateIsTrue(Pageable pageable);
 
     Page<Board> findAllByStateIsTrueAndMbti(MbtiEnum mbtiEnum, Pageable pageable);
+
+    Page<Board> findAllByMemberId(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardRepository.java
@@ -11,5 +11,5 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     Page<Board> findAllByStateIsTrueAndMbti(MbtiEnum mbtiEnum, Pageable pageable);
 
-    Page<Board> findAllByMemberId(Long memberId, Pageable pageable);
+    Page<Board> findAllByMemberIdAndStateIsTrue(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardRepository.java
@@ -4,10 +4,14 @@ import com.example.mssaem_backend.domain.mbti.MbtiEnum;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
-    Page<Board> findAllByStateIsTrue(Pageable pageable);
+    //boardId가 입력되지 않으면 전체 게시글 조회, 입력되면 해당 게시글만 제외하고 잔체 조회
+    @Query("SELECT b FROM Board b WHERE b.state = true AND (:boardId IS NULL OR b.id <> :boardId)")
+    Page<Board> findAllByStateIsTrueAndId(@Param("boardId") Long boardId, Pageable pageable);
 
     Page<Board> findAllByStateIsTrueAndMbti(MbtiEnum mbtiEnum, Pageable pageable);
 

--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
@@ -190,4 +190,18 @@ public class BoardService {
         );
     }
 
+    public PageResponseDto<List<BoardSimpleInfo>> findBoardsByMemberId(Long id, int page,
+        int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Board> result = boardRepository.findAllByMemberId(id, pageable);
+        return new PageResponseDto<>(
+            result.getNumber(),
+            result.getTotalPages(),
+            setBoardSimpleInfo(
+                result
+                    .stream()
+                    .collect(Collectors.toList()))
+        );
+    }
+
 }

--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
@@ -223,7 +223,7 @@ public class BoardService {
                     board.getMember().getId(),
                     board.getMember().getNickName(),
                     board.getMember().getMbti(),
-                    badgeRepository.findBadgeWithStateTrueByMember(board.getMember())
+                    badgeRepository.findBadgeByMemberAndStateTrue(board.getMember())
                         .orElse(new Badge()).getName(),
                     board.getMember().getProfileImageUrl()
                 )
@@ -231,7 +231,7 @@ public class BoardService {
             .board(board)
             .imgUrlList(boardImageService.getImgUrls(board))
             .createdAt(calculateTime(board.getCreatedAt(), 2))
-            .commentCount(boardCommentRepository.countWithStateTrueByBoard(board))
+            .commentCount(boardCommentRepository.countByBoardAndStateTrue(board))
             .isAllowed(isAllowed)
             .boardCommentSimpleInfo(boardCommentService.setBoardCommentSimpleInfo(
                 boardCommentService.boardCommentList(board.getId())))

--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
@@ -165,9 +165,9 @@ public class BoardService {
 
 
     //게시글 전체 조회
-    public PageResponseDto<List<BoardSimpleInfo>> findBoards(int page, int size) {
+    public PageResponseDto<List<BoardSimpleInfo>> findBoards(int page, int size , Long boardId) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<Board> result = boardRepository.findAllByStateIsTrue(pageable);
+        Page<Board> result = boardRepository.findAllByStateIsTrueAndId(boardId , pageable);
         return new PageResponseDto<>(
             result.getNumber(),
             result.getTotalPages(),

--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
@@ -12,6 +12,7 @@ import com.example.mssaem_backend.domain.boardimage.BoardImage;
 import com.example.mssaem_backend.domain.boardimage.BoardImageRepository;
 import com.example.mssaem_backend.domain.boardimage.BoardImageService;
 import com.example.mssaem_backend.domain.like.LikeRepository;
+import com.example.mssaem_backend.domain.mbti.MbtiEnum;
 import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.domain.member.dto.MemberResponseDto.MemberSimpleInfo;
 import com.example.mssaem_backend.global.common.dto.PageResponseDto;
@@ -164,6 +165,21 @@ public class BoardService {
     public PageResponseDto<List<BoardSimpleInfo>> findBoards(int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<Board> result = boardRepository.findAllByStateIsTrue(pageable);
+        return new PageResponseDto<>(
+            result.getNumber(),
+            result.getTotalPages(),
+            setBoardSimpleInfo(
+                result
+                    .stream()
+                    .collect(Collectors.toList()))
+        );
+    }
+
+    //Mbti 카테고리 별 게시글 전체 조회
+    public PageResponseDto<List<BoardSimpleInfo>> findBoardsByMbti(MbtiEnum mbti, int page,
+        int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Board> result = boardRepository.findAllByStateIsTrueAndMbti(mbti, pageable);
         return new PageResponseDto<>(
             result.getNumber(),
             result.getTotalPages(),

--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
@@ -1,5 +1,7 @@
 package com.example.mssaem_backend.domain.board;
 
+import static com.example.mssaem_backend.global.common.Time.calculateTime;
+
 import com.example.mssaem_backend.domain.badge.Badge;
 import com.example.mssaem_backend.domain.badge.BadgeRepository;
 import com.example.mssaem_backend.domain.board.dto.BoardRequestDto.PatchBoardReq;
@@ -12,7 +14,6 @@ import com.example.mssaem_backend.domain.boardimage.BoardImageService;
 import com.example.mssaem_backend.domain.like.LikeRepository;
 import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.domain.member.dto.MemberResponseDto.MemberSimpleInfo;
-import com.example.mssaem_backend.global.common.Time;
 import com.example.mssaem_backend.global.common.dto.PageResponseDto;
 import com.example.mssaem_backend.global.config.exception.BaseException;
 import com.example.mssaem_backend.global.config.exception.errorCode.BoardErrorCode;
@@ -24,6 +25,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -86,7 +88,7 @@ public class BoardService {
                     board.getMbti(),
                     board.getLikeCount(),
                     boardCommentRepository.countWithStateTrueByBoard(board),
-                    Time.calculateTime(board.getCreatedAt(), 3),
+                    calculateTime(board.getCreatedAt(), 3),
                     new MemberSimpleInfo(
                         board.getMember().getId(),
                         board.getMember().getNickName(),
@@ -156,4 +158,20 @@ public class BoardService {
             throw new BaseException(BoardErrorCode.BOARD_NOT_FOUND);
         }
     }
+
+
+    //게시글 전체 조회
+    public PageResponseDto<List<BoardSimpleInfo>> findBoards(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Board> result = boardRepository.findAllByStateIsTrue(pageable);
+        return new PageResponseDto<>(
+            result.getNumber(),
+            result.getTotalPages(),
+            setBoardSimpleInfo(
+                result
+                    .stream()
+                    .collect(Collectors.toList()))
+        );
+    }
+
 }

--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
@@ -170,16 +170,16 @@ public class BoardService {
 
 
     //게시글 전체 조회
-    public PageResponseDto<List<BoardSimpleInfo>> findBoards(int page, int size , Long boardId) {
+    public PageResponseDto<List<BoardSimpleInfo>> findBoards(int page, int size, Long boardId) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<Board> result = boardRepository.findAllByStateIsTrueAndId(boardId , pageable);
+        Page<Board> result = boardRepository.findAllByStateIsTrueAndId(boardId, pageable);
         return new PageResponseDto<>(
             result.getNumber(),
             result.getTotalPages(),
             setBoardSimpleInfo(
                 result
                     .stream()
-                    .collect(Collectors.toList()))
+                    .collect(Collectors.toList()), 3)
         );
     }
 
@@ -194,7 +194,7 @@ public class BoardService {
             setBoardSimpleInfo(
                 result
                     .stream()
-                    .collect(Collectors.toList()))
+                    .collect(Collectors.toList()), 3)
         );
     }
 
@@ -209,7 +209,7 @@ public class BoardService {
             setBoardSimpleInfo(
                 result
                     .stream()
-                    .collect(Collectors.toList()))
+                    .collect(Collectors.toList()), 3)
         );
     }
 

--- a/src/main/java/com/example/mssaem_backend/domain/board/dto/BoardResponseDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/dto/BoardResponseDto.java
@@ -1,8 +1,12 @@
 package com.example.mssaem_backend.domain.board.dto;
 
+import com.example.mssaem_backend.domain.board.Board;
+import com.example.mssaem_backend.domain.boardcomment.dto.BoardCommentResponseDto.BoardCommentSimpleInfo;
 import com.example.mssaem_backend.domain.mbti.MbtiEnum;
 import com.example.mssaem_backend.domain.member.dto.MemberResponseDto.MemberSimpleInfo;
+import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -35,6 +39,39 @@ public class BoardResponseDto {
             this.commentCount = commentCount;
             this.createdAt = createdAt;
             this.memberSimpleInfo = memberSimpleInfo;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetBoardRes {
+
+        private MemberSimpleInfo memberSimpleInfo;
+        private Long boardId;
+        private String title;
+        private String content;
+        private List<String> imgUrlList;
+        private String createdAt;
+        private Long likeCount;
+        private Long commentCount;
+        private Boolean isAllowed;
+        private List<BoardCommentSimpleInfo> boardCommentSimpleInfo;
+
+        @Builder
+        public GetBoardRes(MemberSimpleInfo memberSimpleInfo, Board board, List<String> imgUrlList,
+            String createdAt, Long commentCount, Boolean isAllowed,
+            List<BoardCommentSimpleInfo> boardCommentSimpleInfo) {
+            this.memberSimpleInfo = memberSimpleInfo;
+            this.boardId = board.getId();
+            this.title = board.getTitle();
+            this.content = board.getContent();
+            this.imgUrlList = imgUrlList;
+            this.createdAt = createdAt;
+            this.likeCount = board.getLikeCount();
+            this.commentCount = commentCount;
+            this.isAllowed = isAllowed;
+            this.boardCommentSimpleInfo = boardCommentSimpleInfo;
         }
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardComment.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardComment.java
@@ -1,6 +1,7 @@
 package com.example.mssaem_backend.domain.boardcomment;
 
 import com.example.mssaem_backend.domain.board.Board;
+import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
@@ -41,4 +42,7 @@ public class BoardComment extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Board board;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
 }

--- a/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardComment.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardComment.java
@@ -45,4 +45,5 @@ public class BoardComment extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
+
 }

--- a/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentRepository.java
@@ -1,9 +1,12 @@
 package com.example.mssaem_backend.domain.boardcomment;
 
 import com.example.mssaem_backend.domain.board.Board;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BoardCommentRepository extends JpaRepository<BoardComment, Long> {
 
     Long countWithStateTrueByBoard(Board board);
+
+    List<BoardComment> findAllByBoardId(Long id);
 }

--- a/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentService.java
@@ -36,7 +36,7 @@ public class BoardCommentService {
                         boardComment.getMember().getId(),
                         boardComment.getMember().getNickName(),
                         boardComment.getMember().getMbti(),
-                        badgeRepository.findBadgeWithStateTrueByMember(boardComment.getMember())
+                        badgeRepository.findBadgeByMemberAndStateTrue(boardComment.getMember())
                             .orElse(new Badge()).getName(),
                         boardComment.getMember().getProfileImageUrl()
                     )

--- a/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentService.java
@@ -1,9 +1,52 @@
 package com.example.mssaem_backend.domain.boardcomment;
 
+import static com.example.mssaem_backend.global.common.Time.calculateTime;
+
+import com.example.mssaem_backend.domain.badge.Badge;
+import com.example.mssaem_backend.domain.badge.BadgeRepository;
+import com.example.mssaem_backend.domain.boardcomment.dto.BoardCommentResponseDto.BoardCommentSimpleInfo;
+import com.example.mssaem_backend.domain.member.dto.MemberResponseDto.MemberSimpleInfo;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service
 public class BoardCommentService {
+
+    private final BoardCommentRepository boardCommentRepository;
+    private final BadgeRepository badgeRepository;
+
+    public List<BoardCommentSimpleInfo> setBoardCommentSimpleInfo(
+        List<BoardComment> boardComments) {
+        List<BoardCommentSimpleInfo> boardCommentSimpleInfoList = new ArrayList<>();
+
+        for (BoardComment boardComment : boardComments) {
+            boardCommentSimpleInfoList.add(
+                new BoardCommentSimpleInfo(
+                    boardComment.getContent(),
+                    boardComment.getLikeCount(),
+                    boardComment.getDepth(),
+                    boardComment.getParentId(),
+                    boardComment.getOrders(),
+                    boardComment.isState(),
+                    calculateTime(boardComment.getCreatedAt(), 3),
+                    new MemberSimpleInfo(
+                        boardComment.getMember().getId(),
+                        boardComment.getMember().getNickName(),
+                        boardComment.getMember().getMbti(),
+                        badgeRepository.findBadgeWithStateTrueByMember(boardComment.getMember())
+                            .orElse(new Badge()).getName(),
+                        boardComment.getMember().getProfileImageUrl()
+                    )
+                )
+            );
+        }
+        return boardCommentSimpleInfoList;
+    }
+
+    public List<BoardComment> boardCommentList(Long boardId) {
+        return boardCommentRepository.findAllByBoardId(boardId);
+    }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/boardcomment/dto/BoardCommentResponseDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardcomment/dto/BoardCommentResponseDto.java
@@ -1,0 +1,38 @@
+package com.example.mssaem_backend.domain.boardcomment.dto;
+
+import com.example.mssaem_backend.domain.boardcomment.BoardComment;
+import com.example.mssaem_backend.domain.member.dto.MemberResponseDto.MemberSimpleInfo;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class BoardCommentResponseDto {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class BoardCommentSimpleInfo {
+
+        private String Content;
+        private Long likeCount;
+        private Integer depth;
+        private Integer parentId;
+        private Integer orders;
+        private boolean state;
+        String createdAt;
+        private MemberSimpleInfo memberSimpleInfo;
+
+        public BoardCommentSimpleInfo(MemberSimpleInfo memberSimpleInfo, BoardComment boardComment,
+            String createdAt) {
+            this.Content = boardComment.getContent();
+            this.likeCount = boardComment.getLikeCount();
+            this.depth = boardComment.getDepth();
+            this.parentId = boardComment.getParentId();
+            this.orders = boardComment.getOrders();
+            this.state = boardComment.isState();
+            this.memberSimpleInfo = memberSimpleInfo;
+            this.createdAt = createdAt;
+        }
+    }
+
+}

--- a/src/main/java/com/example/mssaem_backend/domain/boardimage/BoardImageService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardimage/BoardImageService.java
@@ -3,7 +3,9 @@ package com.example.mssaem_backend.domain.boardimage;
 import com.example.mssaem_backend.domain.board.Board;
 import com.example.mssaem_backend.global.s3.S3Service;
 import com.example.mssaem_backend.global.s3.dto.S3Result;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -50,5 +52,17 @@ public class BoardImageService {
         }
         //DB에 저장된 이미지 삭제
         deleteImage(board);
+    }
+
+    //해당 게시글 이미지 url 리스트 가져오기
+    public List<String> getImgUrls(Board board) {
+        List<BoardImage> boardImageList = boardImageRepository.findAllByBoardId(board.getId());
+
+        if (boardImageList.isEmpty()) {
+            return Collections.singletonList("default");
+        }
+        return boardImageList.stream()
+            .map(BoardImage::getImageUrl)
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/bookmark/BookMark.java
+++ b/src/main/java/com/example/mssaem_backend/domain/bookmark/BookMark.java
@@ -16,7 +16,6 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 
 @DynamicInsert
@@ -38,4 +37,18 @@ public class BookMark extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
+
+    public BookMark(MbtiEnum mbti , Member member) {
+        this.mbti = mbti;
+        this.member = member;
+    }
+
+    public void updateBookMark() {
+        //현재 상태가 true 라면 false로 변경
+        if (this.state == true) {
+            this.state = false;
+        } else {
+            this.state = true;
+        }
+    }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/bookmark/BookMarkController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/bookmark/BookMarkController.java
@@ -1,10 +1,13 @@
 package com.example.mssaem_backend.domain.bookmark;
 
+import com.example.mssaem_backend.domain.bookmark.dto.BookMarkResponseDto.BookMarkInfo;
 import com.example.mssaem_backend.domain.mbti.MbtiEnum;
 import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.global.config.security.auth.CurrentMember;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,6 +24,10 @@ public class BookMarkController {
         @RequestParam MbtiEnum mbtiEnum) {
         return ResponseEntity.ok(bookMarkService.updateBookMark(member, mbtiEnum));
     }
-
+    //즐겨찾기 목록 조회
+    @GetMapping("/member/bookmark")
+    public ResponseEntity<List<BookMarkInfo>> findBookMarkList(@CurrentMember Member member) {
+        return ResponseEntity.ok(bookMarkService.getBookMarkList(member));
+    }
 
 }

--- a/src/main/java/com/example/mssaem_backend/domain/bookmark/BookMarkController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/bookmark/BookMarkController.java
@@ -1,9 +1,26 @@
 package com.example.mssaem_backend.domain.bookmark;
 
+import com.example.mssaem_backend.domain.mbti.MbtiEnum;
+import com.example.mssaem_backend.domain.member.Member;
+import com.example.mssaem_backend.global.config.security.auth.CurrentMember;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
 public class BookMarkController {
+
+    private final BookMarkService bookMarkService;
+
+    //카테고리 즐겨찾기 누르기
+    @PostMapping("/member/bookmark")
+    public ResponseEntity<String> updateBookMark(@CurrentMember Member member,
+        @RequestParam MbtiEnum mbtiEnum) {
+        return ResponseEntity.ok(bookMarkService.updateBookMark(member, mbtiEnum));
+    }
+
+
 }

--- a/src/main/java/com/example/mssaem_backend/domain/bookmark/BookMarkRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/bookmark/BookMarkRepository.java
@@ -1,6 +1,13 @@
 package com.example.mssaem_backend.domain.bookmark;
 
+import com.example.mssaem_backend.domain.mbti.MbtiEnum;
+import com.example.mssaem_backend.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookMarkRepository extends JpaRepository<BookMark, Long> {
+
+    BookMark findByMemberAndMbti(Member member, MbtiEnum mbtiEnum);
+
+    Boolean existsBookMarkByMemberAndMbti(Member member, MbtiEnum mbtiEnum);
+
 }

--- a/src/main/java/com/example/mssaem_backend/domain/bookmark/BookMarkRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/bookmark/BookMarkRepository.java
@@ -2,6 +2,7 @@ package com.example.mssaem_backend.domain.bookmark;
 
 import com.example.mssaem_backend.domain.mbti.MbtiEnum;
 import com.example.mssaem_backend.domain.member.Member;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookMarkRepository extends JpaRepository<BookMark, Long> {
@@ -10,4 +11,5 @@ public interface BookMarkRepository extends JpaRepository<BookMark, Long> {
 
     Boolean existsBookMarkByMemberAndMbti(Member member, MbtiEnum mbtiEnum);
 
+    List<BookMark> findAllByStateIsTrueAndMember(Member member);
 }

--- a/src/main/java/com/example/mssaem_backend/domain/bookmark/BookMarkService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/bookmark/BookMarkService.java
@@ -1,9 +1,29 @@
 package com.example.mssaem_backend.domain.bookmark;
 
+import com.example.mssaem_backend.domain.mbti.MbtiEnum;
+import com.example.mssaem_backend.domain.member.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
 public class BookMarkService {
+
+    private final BookMarkRepository bookMarkRepository;
+
+    @Transactional
+    public String updateBookMark(Member member, MbtiEnum mbti) {
+        //해당 bookmark가 member, mbti 에 대해 존재하는 지 확인
+        if(bookMarkRepository.existsBookMarkByMemberAndMbti(member, mbti)){
+            //존재한다면 해당 즐겨찾기 상태 변경
+            BookMark bookMark = bookMarkRepository.findByMemberAndMbti(member, mbti);
+            bookMark.updateBookMark();
+        } else if (!bookMarkRepository.existsBookMarkByMemberAndMbti(member, mbti)){
+            //존재하지 않는다면 새로운 즐겨찾기 추가
+            bookMarkRepository.save(new BookMark(mbti, member));
+        }
+        return "즐겨찾기 추가 완료";
+    }
+
 }

--- a/src/main/java/com/example/mssaem_backend/domain/bookmark/BookMarkService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/bookmark/BookMarkService.java
@@ -1,7 +1,9 @@
 package com.example.mssaem_backend.domain.bookmark;
 
+import com.example.mssaem_backend.domain.bookmark.dto.BookMarkResponseDto.BookMarkInfo;
 import com.example.mssaem_backend.domain.mbti.MbtiEnum;
 import com.example.mssaem_backend.domain.member.Member;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,15 +17,27 @@ public class BookMarkService {
     @Transactional
     public String updateBookMark(Member member, MbtiEnum mbti) {
         //해당 bookmark가 member, mbti 에 대해 존재하는 지 확인
-        if(bookMarkRepository.existsBookMarkByMemberAndMbti(member, mbti)){
+        if (bookMarkRepository.existsBookMarkByMemberAndMbti(member, mbti)) {
             //존재한다면 해당 즐겨찾기 상태 변경
             BookMark bookMark = bookMarkRepository.findByMemberAndMbti(member, mbti);
             bookMark.updateBookMark();
-        } else if (!bookMarkRepository.existsBookMarkByMemberAndMbti(member, mbti)){
+        } else if (!bookMarkRepository.existsBookMarkByMemberAndMbti(member, mbti)) {
             //존재하지 않는다면 새로운 즐겨찾기 추가
             bookMarkRepository.save(new BookMark(mbti, member));
         }
         return "즐겨찾기 추가 완료";
     }
 
+    //즐겨찾기 목록 조회
+    public List<BookMarkInfo> getBookMarkList(Member member) {
+        List<BookMark> bookMarkList = bookMarkRepository.findAllByStateIsTrueAndMember(member);
+
+        List<BookMarkInfo> bookMarkInfoList = bookMarkList.stream()
+            .map(bookMark -> BookMarkInfo.builder()
+                .memberId(bookMark.getMember().getId())
+                .mbti(bookMark.getMbti())
+                .build())
+            .toList();
+        return bookMarkInfoList;
+    }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/bookmark/dto/BookMarkResponseDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/bookmark/dto/BookMarkResponseDto.java
@@ -1,0 +1,22 @@
+package com.example.mssaem_backend.domain.bookmark.dto;
+
+import com.example.mssaem_backend.domain.mbti.MbtiEnum;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class BookMarkResponseDto {
+
+    @Getter
+    @NoArgsConstructor
+    public static class BookMarkInfo {
+
+        private Long memberId;
+        private MbtiEnum mbti;
+        @Builder
+        public BookMarkInfo (Long memberId , MbtiEnum mbti){
+            this.memberId = memberId;
+            this.mbti = mbti;
+        }
+    }
+}


### PR DESCRIPTION
## 요약

- 게시글 조회 관련 API , 카테고리 즐겨찾기 관련 API

## 상세 내용

- 게시글 전체 조회
- 게시글 상세 조회
- Mbti 카테고리 별 게시글 전체 조회
- 특정 멤버별 게시글 전체 조회

### BoardService
- `findBoards()` : 게시글 전체 조회 메소드
   - `boardRepository.findAllByStateIsTrueAndId(boardId , pageable)` 을 통해 boardId가 입력되지 않으면 전체 게시글 조회, 입력되면 해당 게시글만 제외하고 전체 조회해옴
   - 조회해온 Page를 List로 변환
   - PageResponseDto에 페이지 정보들과 `setBoardSimpleInfo()`을 이용하여 정보 매핑
- `setBoardSimpleInfo()` : 재사용을 통해 조회해온 게시글을 바탕으로 List 형식으로 Dto에 매핑
- `findBoardsByMbti()` : 카테고리별 게시글 전체 조회 메소드
- `findBoardsByMemberId()` :  특정 멤버별 게시글 전체 조회 메소드
- `findBoardById()` :  게시글 상세 조회 메소드
   - `Boolean isAllowed = (viewer != null && viewer.getId().equals(member.getId()))` 를 통해 게시글 수정,삭제 권한 확인
   - `boardCommentSimpleInfo(boardCommentService.setBoardCommentSimpleInfo(
                boardCommentService.boardCommentList(board.getId())))` 을 통해 해당 게시글 댓글 정보 조회

### BoardRepository
- `@Query("SELECT b FROM Board b WHERE b.state = true AND (:boardId IS NULL OR b.id <> :boardId)")
    Page<Board> findAllByStateIsTrueAndId(@Param("boardId") Long boardId, Pageable pageable)` : boardId가 입력되지 않으면 전체 게시글 조회, 입력되면 해당 게시글만 제외하고 전체 조회
- `Page<Board> findAllByStateIsTrueAndMbti(MbtiEnum mbtiEnum, Pageable pageable)` : 현재 상태가 true 이고 해당 mbti에 해당하는 게시글 조회
- `Page<Board> findAllByMemberIdAndStateIsTrue(Long memberId, Pageable pageable)` : 현재 상태가 true 이고 해당 member에 해당하는 게시글 조회

### BoardCommentService
- `setBoardCommentSimpleInfo()` : BoardComment를 List 형태로 를 받아와 List형태로 BoardCommentSimpleInfo Dto 매핑
- `boardCommentList()` : 해당 게시글에 대한 BoardComment 리스트 반환
### BoardCommentRepository
- `List<BoardComment> findAllByBoardId(Long id)` : 해당 게시글에 대한 BoardCommentList 조회
---
- 카테고리 즐겨찾기 누르기
- 카테고리 즐겨찾기 목록 조회
### BookMarkController
```java
    //카테고리 즐겨찾기 누르기
    @PostMapping("/member/bookmark")
    public ResponseEntity<String> updateBookMark(@CurrentMember Member member,
        @RequestParam MbtiEnum mbtiEnum) {
        return ResponseEntity.ok(bookMarkService.updateBookMark(member, mbtiEnum));
    }
    //즐겨찾기 목록 조회
    @GetMapping("/member/bookmark")
    public ResponseEntity<List<BookMarkInfo>> findBookMarkList(@CurrentMember Member member) {
        return ResponseEntity.ok(bookMarkService.getBookMarkList(member));
    }
```
- 이 기능은 현재 로그인한 멤버만 사용할 수 있다 생각되어 @CurrentMember 어노테이션 추가.
### BookMarkService
- `updateBookMark()` : 해당 mbti에 대한 북마크가 존재하는 지 확인 후 존재X 면 추가, 존재O 면 상태 변경
- `getBookMarkList()` : BookMark를 List 형태로 받아와 List 형태로 BookMarkInfo Dto 매핑하여 즐겨찾기 목록 조회
### BookMarkRepository
```java
    BookMark findByMemberAndMbti(Member member, MbtiEnum mbtiEnum);

    Boolean existsBookMarkByMemberAndMbti(Member member, MbtiEnum mbtiEnum);

    List<BookMark> findAllByStateIsTrueAndMember(Member member);
```

## 질문 및 이외 사항

- 게시글 전체 조회
```java
    @GetMapping("/board")
    public ResponseEntity<PageResponseDto<List<BoardSimpleInfo>>> findBoards(@RequestParam int page,
        @RequestParam int size, @RequestParam(required = false) Long boardId) {
        return ResponseEntity.ok(boardService.findBoards(page, size, boardId));
    }
```
위와 같이 `게시글 상세 조회시, 밑에 목록에서 해당 게시글 제외하고 전체 조회` 하는 기능을 구현하기 위해 `게시글 전체 조회` api에서 추가로 boardId를 입력 받도록 하였습니다. 입력 받은 boardId를 제외하고 목록을 보여줄 수 있도록 아래와 같이 쿼리문을 작성하였습니다.
```java
    //boardId가 입력되지 않으면 전체 게시글 조회, 입력되면 해당 게시글만 제외하고 잔체 조회
    @Query("SELECT b FROM Board b WHERE b.state = true AND (:boardId IS NULL OR b.id <> :boardId)")
    Page<Board> findAllByStateIsTrueAndId(@Param("boardId") Long boardId, Pageable pageable);
```
프론트에서 게시글 상세조회 api 하나랑 현재 게시글 제외한 모든 게시판 전체 조회api 하나, 이렇게 두개로 보내주시는게 편하다고 하여 이렇게 구현해보았습니다. 이 부분에서 잘못된 게 있을까요?

- MBTI 카테고리별 게시글 전체 조회 / 특정 멤버별 게시글 전체 조회 URL 관련
```java
    @GetMapping("/board/mbti/{mbti}")

    @GetMapping("/board/member/{memberId}")
```
위와 같이 URL을 설정하였는데, 이렇게 해도 괜찮을까요?

- BoardCommentService 관련
`setBoardCommentSimpleInfo()` 와 `boardCommentList()` 모두 public 입니다. 두개 하나 중에는 private으로 설정할 수 있을 것 같은데, 아닌 것 같기도 하고 애매해서 여러분들의 생각을 여쭤봅니다!

- 즐겨찾기 API 관련
즐겨찾기 누르기, 즐겨찾기 목록 조회 모두 로그인한 멤버만 사용할 수 있도록 @CurrnetMember 를 추가하였습니다,. 여러분들의 생각과 일치하는지 여쭤봅니다!

## 이슈 번호

- close #24 
