### PR TITLE
고민글 생성/수정/삭제/완료 API

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/member/MemberService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/member/MemberService.java
@@ -102,7 +102,8 @@ public class MemberService {
     // 홈 화면에 보여줄 인기 M쌤 조회
     public List<TeacherInfo> findHotTeacherForHome() {
         PageRequest pageRequest = PageRequest.of(0, 4);
-        Page<Member> solveMembers = worryBoardRepository.findSolveMemberWithMoreThanOneIdAndStateTrue(
+        Page<Member> solveMembers = worryBoardRepository.findSolveMemberWithMoreThanOneIdAndIsSolvedTrueAndStateTrue(
+
             LocalDateTime.now().minusMonths(1),
             pageRequest);
         List<TeacherInfo> teacherInfos = new ArrayList<>();
@@ -113,7 +114,7 @@ public class MemberService {
                     solveMember.getId(),
                     solveMember.getNickName(),
                     solveMember.getMbti(),
-                    badgeRepository.findBadgeWithStateTrueByMember(solveMember)
+                    badgeRepository.findBadgeByMemberAndStateTrue(solveMember)
                         .orElse(new Badge())
                         .getName(),
                     solveMember.getProfileImageUrl(),

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoard.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoard.java
@@ -10,7 +10,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 
 @Getter

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoard.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoard.java
@@ -13,12 +13,12 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 
-@Setter
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class WorryBoard extends BaseTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -48,13 +48,17 @@ public class WorryBoard extends BaseTimeEntity {
     @ColumnDefault("0")
     private Long hits;
 
-    //테스트 코드용
     @Builder
-    public WorryBoard(String title, String content, MbtiEnum targetMbti, boolean state, Member member) {
+    public WorryBoard(String title, String content, MbtiEnum targetMbti,
+        Member member) {
         this.title = title;
         this.content = content;
         this.targetMbti = targetMbti;
-        this.state = state;
         this.member = member;
+    }
+
+    public void solveWorryBoard(boolean state, Member solveMember) {
+        this.state = state;
+        this.solveMember = solveMember;
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoard.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoard.java
@@ -79,4 +79,8 @@ public class WorryBoard extends BaseTimeEntity {
         this.content = content;
         this.targetMbti = targetMbti;
     }
+
+    public void deleteWorryBoard() {
+        this.state = false;
+    }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoard.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoard.java
@@ -62,4 +62,10 @@ public class WorryBoard extends BaseTimeEntity {
         this.state = state;
         this.solveMember = solveMember;
     }
+
+    public void modifyWorryBoard(String title, String content, MbtiEnum targetMbti) {
+        this.title = title;
+        this.content = content;
+        this.targetMbti = targetMbti;
+    }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoard.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoard.java
@@ -47,7 +47,7 @@ public class WorryBoard extends BaseTimeEntity {
 
     private boolean state = true; //고민글 삭제시 : false
 
-    private boolean isSolved; //true : 해결, false : 해결 안함
+    private Boolean isSolved = false; //true : 해결, false : 해결 안함
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member; //이 고민글을 신청한 유저
@@ -69,9 +69,10 @@ public class WorryBoard extends BaseTimeEntity {
         this.member = member;
     }
 
-    public void solveWorryBoard(boolean state, Member solveMember) {
-        this.state = state;
+    public void solveWorryBoard(Member solveMember) {
+        this.isSolved = true;
         this.solveMember = solveMember;
+        this.solvedAt = LocalDateTime.now();
     }
 
     public void modifyWorryBoard(String title, String content, MbtiEnum targetMbti) {

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardController.java
@@ -68,7 +68,7 @@ public class WorryBoardController {
     //고민 게시판(해결 X) - mbti별 고민글 조회
     @GetMapping("worry-board/waiting/filter")
     public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findWaitingWorriesByMbti(
-        @RequestParam("fromMbti") String strFromMbti, @RequestParam("toMbti") String strToMbti,
+        @RequestParam String strFromMbti, @RequestParam String strToMbti,
         @RequestParam int page, @RequestParam int size) {
         return ResponseEntity.ok(
             worryBoardService.findWorriesByMbti(false, strFromMbti, strToMbti, page, size));
@@ -77,7 +77,7 @@ public class WorryBoardController {
     //고민 게시판(해결 O) - mbti별 고민글 조회
     @GetMapping("worry-board/solved/filter")
     public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findSolvedWorriesByMbti(
-        @RequestParam("fromMbti") String strFromMbti, @RequestParam("toMbti") String strToMbti,
+        @RequestParam String strFromMbti, @RequestParam String strToMbti,
         @RequestParam int page, @RequestParam int size) {
         return ResponseEntity.ok(
             worryBoardService.findWorriesByMbti(true, strFromMbti, strToMbti, page, size));
@@ -88,7 +88,6 @@ public class WorryBoardController {
     public ResponseEntity<List<GetWorriesRes>> findWaitingWorriesForHome() {
         return ResponseEntity.ok(worryBoardService.findWorriesForHome());
     }
-
 
     //고민 해결 완료 처리
     @PatchMapping("/member/worry-board/{id}/solved")

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardController.java
@@ -3,6 +3,7 @@ package com.example.mssaem_backend.domain.worryboard;
 import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.GetWorriesReq;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.PatchWorrySolvedReq;
+import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.PostWorryReq;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardResponseDto.GetWorriesRes;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardResponseDto.GetWorryRes;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardResponseDto.PatchWorrySolvedRes;
@@ -16,7 +17,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @RestController
@@ -78,8 +81,18 @@ public class WorryBoardController {
 
     //고민 해결 완료 처리
     @PostMapping("/member/worry-board/solved")
-    public ResponseEntity<PatchWorrySolvedRes> solvedWorryBoard(@CurrentMember Member currentMember, @RequestBody
-    PatchWorrySolvedReq patchWorryReq) {
+    public ResponseEntity<PatchWorrySolvedRes> solvedWorryBoard(@CurrentMember Member currentMember,
+        @RequestBody PatchWorrySolvedReq patchWorryReq) {
         return ResponseEntity.ok(worryBoardService.solvedWorryBoard(patchWorryReq));
+    }
+
+    //고민글 생성
+    @PostMapping("/member/worry-board")
+    public ResponseEntity<String> createWorryBoard(@CurrentMember Member currentMember,
+        @RequestPart(value = "postWorryBoardReq")
+        PostWorryReq postWorryReq,
+        @RequestPart(value = "image", required = false) List<MultipartFile> multipartFiles) {
+        return ResponseEntity.ok(
+            worryBoardService.createWorryBoard(currentMember, postWorryReq, multipartFiles));
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardController.java
@@ -13,6 +13,7 @@ import com.example.mssaem_backend.global.config.security.auth.CurrentMember;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -108,8 +109,16 @@ public class WorryBoardController {
     @PatchMapping("/member/worry-board")
     public ResponseEntity<String> modifyWorryBoard(@CurrentMember Member currentMember,
         @RequestPart(value = "patchWorryReq") PatchWorryReq patchWorryReq,
-        @RequestPart(value ="image", required = false) List<MultipartFile> multipartFiles) {
+        @RequestPart(value = "image", required = false) List<MultipartFile> multipartFiles) {
         return ResponseEntity.ok(
             worryBoardService.modifyWorryBoard(currentMember, patchWorryReq, multipartFiles));
+    }
+
+    //고민글 삭제
+    @DeleteMapping("/member/worry-board/{id}")
+    public ResponseEntity<String> deleteWorryBoard(@CurrentMember Member currentMember,
+        @PathVariable Long id) {
+        return ResponseEntity.ok(
+            worryBoardService.deleteWorryBoard(currentMember, id));
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardController.java
@@ -2,8 +2,10 @@ package com.example.mssaem_backend.domain.worryboard;
 
 import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.GetWorriesReq;
+import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.PatchWorrySolvedReq;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardResponseDto.GetWorriesRes;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardResponseDto.GetWorryRes;
+import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardResponseDto.PatchWorrySolvedRes;
 import com.example.mssaem_backend.global.common.dto.PageResponseDto;
 import com.example.mssaem_backend.global.config.security.auth.CurrentMember;
 import java.util.List;
@@ -24,43 +26,60 @@ public class WorryBoardController {
 
     //고민글 조회 (해결 X)
     @GetMapping("/worry-board/waiting")
-    public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findWorriesWaiting(@RequestParam int page, @RequestParam int size) {
+    public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findWorriesWaiting(
+        @RequestParam int page, @RequestParam int size) {
         return ResponseEntity.ok(worryBoardService.findWorriesByState(false, page, size));
     }
 
     //고민글 조회 (해결 O)
     @GetMapping("/worry-board/solved")
-    public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findWorriesSolved(@RequestParam int page, @RequestParam int size) {
+    public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findWorriesSolved(
+        @RequestParam int page, @RequestParam int size) {
         return ResponseEntity.ok(worryBoardService.findWorriesByState(true, page, size));
     }
 
     //고민글 상세 조회
     @GetMapping("/worry-board/{id}")
-    public ResponseEntity<GetWorryRes> findWorryById(@CurrentMember Member viewer,@PathVariable Long id) {
+    public ResponseEntity<GetWorryRes> findWorryById(@CurrentMember Member viewer,
+        @PathVariable Long id) {
         return ResponseEntity.ok(worryBoardService.findWorryById(viewer, id));
     }
 
     //특정 멤버별 올린 고민글 조회
     @GetMapping("/worry-board/post-list")
-    public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findWorriesByMemberId(@RequestParam Long memberId, @RequestParam int page, @RequestParam int size) {
+    public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findWorriesByMemberId(
+        @RequestParam Long memberId, @RequestParam int page, @RequestParam int size) {
         return ResponseEntity.ok(worryBoardService.findWorriesByMemberId(memberId, page, size));
     }
 
     //특정 멤버별 해결한 고민글 조회
     @GetMapping("/worry-board/solve-list")
-    public ResponseEntity<PageResponseDto<List<GetWorriesRes>>>findSolveWorriesByMemberId(@RequestParam Long memberId, @RequestParam int page, @RequestParam int size) {
-        return ResponseEntity.ok(worryBoardService.findSolveWorriesByMemberId(memberId, page, size));
+    public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findSolveWorriesByMemberId(
+        @RequestParam Long memberId, @RequestParam int page, @RequestParam int size) {
+        return ResponseEntity.ok(
+            worryBoardService.findSolveWorriesByMemberId(memberId, page, size));
     }
 
     //고민 게시판(해결 X) - mbti별 고민글 조회
     @PostMapping("worry-board/waiting/filter")
-    public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findWaitingWorriesByMbti(@RequestBody GetWorriesReq getWorriesReq, @RequestParam int page, @RequestParam int size) {
-        return ResponseEntity.ok(worryBoardService.findWorriesByMbti(getWorriesReq, false, page, size));
+    public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findWaitingWorriesByMbti(
+        @RequestBody GetWorriesReq getWorriesReq, @RequestParam int page, @RequestParam int size) {
+        return ResponseEntity.ok(
+            worryBoardService.findWorriesByMbti(getWorriesReq, false, page, size));
     }
 
     //고민 게시판(해결 O) - mbti별 고민글 조회
     @PostMapping("worry-board/solved/filter")
-    public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findSolvedWorriesByMbti(@RequestBody GetWorriesReq getWorriesReq, @RequestParam int page, @RequestParam int size) {
-        return ResponseEntity.ok(worryBoardService.findWorriesByMbti(getWorriesReq, true, page, size));
+    public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findSolvedWorriesByMbti(
+        @RequestBody GetWorriesReq getWorriesReq, @RequestParam int page, @RequestParam int size) {
+        return ResponseEntity.ok(
+            worryBoardService.findWorriesByMbti(getWorriesReq, true, page, size));
+    }
+
+    //고민 해결 완료 처리
+    @PostMapping("/member/worry-board/solved")
+    public ResponseEntity<PatchWorrySolvedRes> solvedWorryBoard(@CurrentMember Member currentMember, @RequestBody
+    PatchWorrySolvedReq patchWorryReq) {
+        return ResponseEntity.ok(worryBoardService.solvedWorryBoard(patchWorryReq));
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardController.java
@@ -34,14 +34,14 @@ public class WorryBoardController {
     @GetMapping("/worry-board/waiting")
     public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findWorriesWaiting(
         @RequestParam int page, @RequestParam int size) {
-        return ResponseEntity.ok(worryBoardService.findWorriesByState(false, page, size));
+        return ResponseEntity.ok(worryBoardService.findWorriesBySolved(false, page, size));
     }
 
     //고민글 조회 (해결 O)
     @GetMapping("/worry-board/solved")
     public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findWorriesSolved(
         @RequestParam int page, @RequestParam int size) {
-        return ResponseEntity.ok(worryBoardService.findWorriesByState(true, page, size));
+        return ResponseEntity.ok(worryBoardService.findWorriesBySolved(true, page, size));
     }
 
     //고민글 상세 조회
@@ -90,10 +90,11 @@ public class WorryBoardController {
 
 
     //고민 해결 완료 처리
-    @PostMapping("/member/worry-board/solved")
-    public ResponseEntity<PatchWorrySolvedRes> solvedWorryBoard(@CurrentMember Member currentMember,
+    @PatchMapping("/member/worry-board/{id}/solved")
+    public ResponseEntity<PatchWorrySolvedRes> solveWorryBoard(@CurrentMember Member currentMember,
+        @PathVariable Long id,
         @RequestBody PatchWorrySolvedReq patchWorryReq) {
-        return ResponseEntity.ok(worryBoardService.solvedWorryBoard(patchWorryReq));
+        return ResponseEntity.ok(worryBoardService.solveWorryBoard(currentMember, id, patchWorryReq));
     }
 
     //고민글 생성
@@ -106,12 +107,13 @@ public class WorryBoardController {
     }
 
     //고민글 수정
-    @PatchMapping("/member/worry-board")
+    @PatchMapping("/member/worry-board/{id}")
     public ResponseEntity<String> modifyWorryBoard(@CurrentMember Member currentMember,
+        @PathVariable Long id,
         @RequestPart(value = "patchWorryReq") PatchWorryReq patchWorryReq,
         @RequestPart(value = "image", required = false) List<MultipartFile> multipartFiles) {
         return ResponseEntity.ok(
-            worryBoardService.modifyWorryBoard(currentMember, patchWorryReq, multipartFiles));
+            worryBoardService.modifyWorryBoard(currentMember, id, patchWorryReq, multipartFiles));
     }
 
     //고민글 삭제

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardController.java
@@ -1,7 +1,6 @@
 package com.example.mssaem_backend.domain.worryboard;
 
 import com.example.mssaem_backend.domain.member.Member;
-import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.GetWorriesReq;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.PatchWorryReq;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.PatchWorrySolvedReq;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.PostWorryReq;
@@ -67,19 +66,21 @@ public class WorryBoardController {
     }
 
     //고민 게시판(해결 X) - mbti별 고민글 조회
-    @PostMapping("worry-board/waiting/filter")
+    @GetMapping("worry-board/waiting/filter")
     public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findWaitingWorriesByMbti(
-        @RequestBody GetWorriesReq getWorriesReq, @RequestParam int page, @RequestParam int size) {
+        @RequestParam("fromMbti") String strFromMbti, @RequestParam("toMbti") String strToMbti,
+        @RequestParam int page, @RequestParam int size) {
         return ResponseEntity.ok(
-            worryBoardService.findWorriesByMbti(getWorriesReq, false, page, size));
+            worryBoardService.findWorriesByMbti(false, strFromMbti, strToMbti, page, size));
     }
 
     //고민 게시판(해결 O) - mbti별 고민글 조회
-    @PostMapping("worry-board/solved/filter")
+    @GetMapping("worry-board/solved/filter")
     public ResponseEntity<PageResponseDto<List<GetWorriesRes>>> findSolvedWorriesByMbti(
-        @RequestBody GetWorriesReq getWorriesReq, @RequestParam int page, @RequestParam int size) {
+        @RequestParam("fromMbti") String strFromMbti, @RequestParam("toMbti") String strToMbti,
+        @RequestParam int page, @RequestParam int size) {
         return ResponseEntity.ok(
-            worryBoardService.findWorriesByMbti(getWorriesReq, true, page, size));
+            worryBoardService.findWorriesByMbti(true, strFromMbti, strToMbti, page, size));
     }
 
     //홈 화면 조회 - 고민글 6개 조회 (해결 X, 최신순)
@@ -94,7 +95,8 @@ public class WorryBoardController {
     public ResponseEntity<PatchWorrySolvedRes> solveWorryBoard(@CurrentMember Member currentMember,
         @PathVariable Long id,
         @RequestBody PatchWorrySolvedReq patchWorryReq) {
-        return ResponseEntity.ok(worryBoardService.solveWorryBoard(currentMember, id, patchWorryReq));
+        return ResponseEntity.ok(
+            worryBoardService.solveWorryBoard(currentMember, id, patchWorryReq));
     }
 
     //고민글 생성

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardController.java
@@ -2,6 +2,7 @@ package com.example.mssaem_backend.domain.worryboard;
 
 import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.GetWorriesReq;
+import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.PatchWorryReq;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.PatchWorrySolvedReq;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.PostWorryReq;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardResponseDto.GetWorriesRes;
@@ -13,6 +14,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -89,10 +91,18 @@ public class WorryBoardController {
     //고민글 생성
     @PostMapping("/member/worry-board")
     public ResponseEntity<String> createWorryBoard(@CurrentMember Member currentMember,
-        @RequestPart(value = "postWorryBoardReq")
-        PostWorryReq postWorryReq,
+        @RequestPart(value = "postWorryReq") PostWorryReq postWorryReq,
         @RequestPart(value = "image", required = false) List<MultipartFile> multipartFiles) {
         return ResponseEntity.ok(
             worryBoardService.createWorryBoard(currentMember, postWorryReq, multipartFiles));
+    }
+
+    //고민글 수정
+    @PatchMapping("/member/worry-board")
+    public ResponseEntity<String> modifyWorryBoard(@CurrentMember Member currentMember,
+        @RequestPart(value = "patchWorryReq") PatchWorryReq patchWorryReq,
+        @RequestPart(value ="image", required = false) List<MultipartFile> multipartFiles) {
+        return ResponseEntity.ok(
+            worryBoardService.modifyWorryBoard(currentMember, patchWorryReq, multipartFiles));
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardRepository.java
@@ -13,24 +13,24 @@ import org.springframework.data.repository.query.Param;
 
 public interface WorryBoardRepository extends JpaRepository<WorryBoard, Long> {
 
-    Page<WorryBoard> findByState(boolean state, Pageable pageable);
+    Page<WorryBoard> findByIsSolvedAndStateTrueOrderByCreatedAtDesc(boolean isSolved, Pageable pageable);
 
-    Page<WorryBoard> findByMemberId(Long memberId, Pageable pageable);
+    Page<WorryBoard> findByMemberIdAndStateTrueOrderByCreatedAtDesc(Long memberId, Pageable pageable);
 
-    Page<WorryBoard> findBySolveMemberId(Long memberId, Pageable pageable);
+    Page<WorryBoard> findBySolveMemberIdAndStateTrueOrderByCreatedAtDesc(Long memberId, Pageable pageable);
 
-    List<WorryBoard> findTop7ByStateFalseOrderByCreatedAtDesc();
+    List<WorryBoard> findTop7ByIsSolvedFalseAndStateTrueOrderByCreatedAtDesc();
 
-    @Query("SELECT wb FROM WorryBoard wb WHERE wb.state = :state AND (:fromMbti IS NULL OR wb.member.mbti = :fromMbti) AND (:toMbti IS NULL OR wb.targetMbti = :toMbti)")
-    Page<WorryBoard> findWorriesByStateAndBothMbti(
-        @Param("state") Boolean state,
+    @Query("SELECT wb FROM WorryBoard wb WHERE wb.state = true AND wb.isSolved = :isSolved AND (:fromMbti IS NULL OR wb.member.mbti = :fromMbti) AND (:toMbti IS NULL OR wb.targetMbti = :toMbti) ORDER BY wb.createdAt DESC")
+    Page<WorryBoard> findWorriesBySolvedAndBothMbtiAndStateTrue(
+        @Param("isSolved") Boolean isSolved,
         @Param("fromMbti") MbtiEnum fromMbti,
         @Param("toMbti") MbtiEnum toMbti,
         Pageable pageable
     );
 
     @Query("SELECT wb.solveMember FROM WorryBoard wb WHERE wb.solvedAt >= :oneMonthAgo AND wb.state = true GROUP BY wb.solveMember.id HAVING COUNT(wb.solveMember.id) >= 1 ORDER BY COUNT(wb.solveMember.id) DESC, wb.solveMember.id")
-    Page<Member> findSolveMemberWithMoreThanOneIdAndStateTrue(
+    Page<Member> findSolveMemberWithMoreThanOneIdAndIsSolvedTrueAndStateTrue(
         @Param("oneMonthAgo") LocalDateTime oneMonthAgo, PageRequest pageRequest);
 
 }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
@@ -25,6 +25,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
@@ -151,6 +152,7 @@ public class WorryBoardService {
     }
 
     //고민글 수정
+    @Transactional
     public String modifyWorryBoard(Member currentMember, PatchWorryReq patchWorryReq,
         List<MultipartFile> multipartFiles) {
         //현재 멤버와 작성자 일치하는 지 확인

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
@@ -19,8 +19,6 @@ import com.example.mssaem_backend.global.common.dto.PageResponseDto;
 import com.example.mssaem_backend.global.config.exception.BaseException;
 import com.example.mssaem_backend.global.config.exception.errorCode.MemberErrorCode;
 import com.example.mssaem_backend.global.config.exception.errorCode.WorryBoardErrorCode;
-import com.example.mssaem_backend.global.s3.S3Service;
-import com.example.mssaem_backend.global.s3.dto.S3Result;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -37,7 +35,6 @@ public class WorryBoardService {
     private final WorryBoardImageService worryBoardImageService;
     private final MemberRepository memberRepository;
     private final BadgeService badgeService;
-    private final S3Service s3Service;
 
     //List<WorryBoard>를 받아서 List<GetWorriesRes> 리스트를 반환하는 함수
     private List<GetWorriesRes> makeGetWorriesResForm(Page<WorryBoard> result) {
@@ -148,7 +145,7 @@ public class WorryBoardService {
 
         //S3 처리 worryBoardImageService에 전달
         if (multipartFiles != null) {
-            worryBoardImageService.uploadWorryImage(worryBoard, multipartFiles);
+            worryBoardImageService.saveWorryImage(worryBoard, multipartFiles);
         }
         return "고민글 생성 완료";
     }
@@ -172,7 +169,7 @@ public class WorryBoardService {
 
         //S3 처리 worryBoardImageService로 전달
         worryBoardImageService.deleteWorryImage(worryBoard, multipartFiles);
-        worryBoardImageService.uploadWorryImage(worryBoard, multipartFiles);
+        worryBoardImageService.saveWorryImage(worryBoard, multipartFiles);
 
         return "고민글 수정 완료";
     }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
@@ -44,6 +44,13 @@ public class WorryBoardService {
             .createdAt(calculateTime(worryBoard.getCreatedAt(), 3)).build()).toList();
     }
 
+    //현재 멤버와 작성자가 같은지 확인하는 함수
+    private void isMatchMemberWithAuthor(Member currentMember, WorryBoard worryBoard) {
+        if (!currentMember.getId().equals(worryBoard.getMember().getId())) {
+            throw new BaseException(MemberErrorCode.INVALID_MEMBER);
+        }
+    }
+
     //고민게시판 - 고민 목록 조회
     public PageResponseDto<List<GetWorriesRes>> findWorriesBySolved(boolean isSolved, int page,
         int size) {
@@ -61,10 +68,12 @@ public class WorryBoardService {
         Member member = worryBoard.getMember();
 
         //수정,삭제 권한 확인
-        Boolean isEditAllowed = (viewer != null && viewer.getId().equals(worryBoard.getMember().getId()));
+        Boolean isEditAllowed = (viewer != null && viewer.getId()
+            .equals(worryBoard.getMember().getId()));
 
         //채팅 시작 권한 확인
-        Boolean isChatAllowed = (viewer != null && viewer.getMbti().equals(worryBoard.getTargetMbti()));
+        Boolean isChatAllowed = (viewer != null && viewer.getMbti()
+            .equals(worryBoard.getTargetMbti()));
 
         return GetWorryRes.builder()
             .worryBoard(worryBoard)
@@ -143,9 +152,7 @@ public class WorryBoardService {
         PatchWorrySolvedReq patchWorryReq) {
         WorryBoard worryBoard = worryBoardRepository.findById(id)
             .orElseThrow(() -> new BaseException(WorryBoardErrorCode.EMPTY_WORRY_BOARD));
-        if (!currentMember.getId().equals(worryBoard.getMember().getId())) {
-            throw new BaseException(MemberErrorCode.INVALID_MEMBER);
-        }
+        isMatchMemberWithAuthor(currentMember, worryBoard);
 
         Member solveMember = memberRepository.findById(patchWorryReq.getWorrySolverId())
             .orElseThrow(() -> new BaseException(MemberErrorCode.EMPTY_MEMBER));
@@ -192,6 +199,7 @@ public class WorryBoardService {
         if (!currentMember.getId().equals(worryBoard.getMember().getId())) {
             throw new BaseException(MemberErrorCode.INVALID_MEMBER);
         }
+        isMatchMemberWithAuthor(currentMember, worryBoard);
 
         //worryBoard 수정하기
         worryBoard.modifyWorryBoard(
@@ -214,9 +222,7 @@ public class WorryBoardService {
         //현재 멤버와 작성자 일치하는 지 확인
         WorryBoard worryBoard = worryBoardRepository.findById(id)
             .orElseThrow(() -> new BaseException(WorryBoardErrorCode.EMPTY_WORRY_BOARD));
-        if (!currentMember.getId().equals(worryBoard.getMember().getId())) {
-            throw new BaseException(MemberErrorCode.INVALID_MEMBER);
-        }
+        isMatchMemberWithAuthor(currentMember, worryBoard);
 
         worryBoard.deleteWorryBoard();
         worryBoardImageService.deleteWorryImage(worryBoard);

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
@@ -186,9 +186,25 @@ public class WorryBoardService {
         );
 
         //S3 처리 worryBoardImageService로 전달
-        worryBoardImageService.deleteWorryImage(worryBoard, multipartFiles);
-        worryBoardImageService.saveWorryImage(worryBoard, multipartFiles);
-
+        worryBoardImageService.deleteWorryImage(worryBoard);
+        if (multipartFiles != null) {
+            worryBoardImageService.saveWorryImage(worryBoard, multipartFiles);
+        }
         return "고민글 수정 완료";
+    }
+
+    //고민글 삭제
+    public String deleteWorryBoard(Member currentMember, Long id) {
+        //현재 멤버와 작성자 일치하는 지 확인
+        WorryBoard worryBoard = worryBoardRepository.findById(id)
+            .orElseThrow(() -> new BaseException(WorryBoardErrorCode.EMPTY_WORRY_BOARD));
+        if (!currentMember.getId().equals(worryBoard.getMember().getId())) {
+            throw new BaseException(MemberErrorCode.INVALID_MEMBER);
+        }
+
+        worryBoard.deleteWorryBoard();
+        worryBoardImageService.deleteWorryImage(worryBoard);
+
+        return "고민글 삭제 완료";
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
@@ -61,7 +61,7 @@ public class WorryBoardService {
         Member member = worryBoard.getMember();
 
         //수정,삭제 권한 확인
-        Boolean isEditAllowed = (viewer != null && viewer.equals(member));
+        Boolean isEditAllowed = (viewer != null && viewer.getId().equals(worryBoard.getMember().getId()));
 
         //채팅 시작 권한 확인
         Boolean isChatAllowed = (viewer != null && viewer.getMbti().equals(worryBoard.getTargetMbti()));

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
@@ -61,7 +61,10 @@ public class WorryBoardService {
         Member member = worryBoard.getMember();
 
         //수정,삭제 권한 확인
-        Boolean isAllowed = (viewer != null && viewer.equals(member));
+        Boolean isEditAllowed = (viewer != null && viewer.equals(member));
+
+        //채팅 시작 권한 확인
+        Boolean isChatAllowed = (viewer != null && viewer.getMbti().equals(worryBoard.getTargetMbti()));
 
         return GetWorryRes.builder()
             .worryBoard(worryBoard)
@@ -71,7 +74,8 @@ public class WorryBoardService {
                 new MemberSimpleInfo(member.getId(), member.getNickName(), member.getMbti(),
                     badgeService.findRepresentativeBadgeByMember(member),
                     member.getProfileImageUrl()))
-            .isAllowed(isAllowed)
+            .isEditAllowed(isEditAllowed)
+            .isChatAllowed(isChatAllowed)
             .build();
     }
 

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
@@ -8,12 +8,12 @@ import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.domain.member.MemberRepository;
 import com.example.mssaem_backend.domain.member.dto.MemberResponseDto.MemberSimpleInfo;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.GetWorriesReq;
+import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.PatchWorryReq;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.PatchWorrySolvedReq;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.PostWorryReq;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardResponseDto.GetWorriesRes;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardResponseDto.GetWorryRes;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardResponseDto.PatchWorrySolvedRes;
-import com.example.mssaem_backend.domain.worryboardimage.WorryBoardImageRepository;
 import com.example.mssaem_backend.domain.worryboardimage.WorryBoardImageService;
 import com.example.mssaem_backend.global.common.dto.PageResponseDto;
 import com.example.mssaem_backend.global.config.exception.BaseException;
@@ -64,12 +64,16 @@ public class WorryBoardService {
         //수정,삭제 권한 확인
         Boolean isAllowed = (viewer != null && viewer.equals(member));
 
-        return GetWorryRes.builder().worryBoard(worryBoard)
+        return GetWorryRes.builder()
+            .worryBoard(worryBoard)
             .imgList(worryBoardImageService.getImgUrls(worryBoard))
-            .createdAt(calculateTime(worryBoard.getCreatedAt(), 2)).memberSimpleInfo(
+            .createdAt(calculateTime(worryBoard.getCreatedAt(), 2))
+            .memberSimpleInfo(
                 new MemberSimpleInfo(member.getId(), member.getNickName(), member.getMbti(),
                     badgeService.findRepresentativeBadgeByMember(member),
-                    member.getProfileImageUrl())).isAllowed(isAllowed).build();
+                    member.getProfileImageUrl()))
+            .isAllowed(isAllowed)
+            .build();
     }
 
     //특정 멤버별 올린 고민 목록 조회
@@ -119,30 +123,66 @@ public class WorryBoardService {
         // 고민글의 상태 바꾸기
         worryBoard.solveWorryBoard(false, solveMember);
         // 평가창에 뜰 memberSimpleInfo, worryBoard Id 반환
-        return PatchWorrySolvedRes.builder().memberSimpleInfo(
-            new MemberSimpleInfo(solveMember.getId(), solveMember.getNickName(),
+        return PatchWorrySolvedRes.builder()
+            .memberSimpleInfo(
+                new MemberSimpleInfo(
+                solveMember.getId(), solveMember.getNickName(),
                 solveMember.getMbti(), badgeService.findRepresentativeBadgeByMember(solveMember),
-                solveMember.getProfileImageUrl())).worryBoardId(worryBoard.getId()).build();
+                solveMember.getProfileImageUrl())
+            )
+            .worryBoardId(worryBoard.getId()).build();
     }
 
+    //고민글 생성
     public String createWorryBoard(Member currentMember, PostWorryReq postWorryReq,
         List<MultipartFile> multipartFiles) {
         //고민글 내용 저장
-        WorryBoard worryBoard = WorryBoard.builder().title(postWorryReq.getTitle())
+        WorryBoard worryBoard = WorryBoard.builder()
+            .title(postWorryReq.getTitle())
             .content(postWorryReq.getContent())
             .targetMbti(postWorryReq.getTargetMbti())
             .member(currentMember)
             .build();
         worryBoardRepository.save(worryBoard);
+
+        //worryBoardImageService에 전달
         if (multipartFiles != null) {
-            //s3에 파일 저장
+            worryBoardImageService.uploadWorryImage(worryBoard, multipartFiles);
+        }
+        return "고민글 생성 완료";
+    }
+
+    //고민글 수정
+    public String modifyWorryBoard(Member currentMember, PatchWorryReq patchWorryReq,
+        List<MultipartFile> multipartFiles) {
+        //현재 멤버와 작성자 일치하는 지 확인
+        WorryBoard worryBoard = worryBoardRepository.findById(patchWorryReq.getWorryBoardId())
+            .orElseThrow(() -> new BaseException(WorryBoardErrorCode.EMPTY_WORRY_BOARD));
+        if (!currentMember.getId().equals(worryBoard.getMember().getId())) {
+            throw new BaseException(MemberErrorCode.INVALID_MEMBER);
+        }
+
+        //worryBoard 수정하기
+        worryBoard.modifyWorryBoard(patchWorryReq.getTitle(), patchWorryReq.getContent(),
+            patchWorryReq.getTargetMbti());
+
+        //worryBoardImageService에 있던 imgUrl 삭제
+        worryBoardImageService.deleteWorryImage(worryBoard);
+
+        //S3에서 파일 삭제하기 && 해당 worryBoard의 worryBoardImage 삭제
+        List<String> worryBoardImgUrls = worryBoardImageService.getImgUrls(worryBoard);
+        worryBoardImgUrls.stream().map(s3Service::parseFileName).forEach(s3Service::deleteFile);
+
+        //S3 새로운 파일 업로드 하기 && worryBoard의 worryBoardImage 생성
+        if (multipartFiles != null) {
             List<S3Result> worryBoardImageList = s3Service.uploadFile(multipartFiles);
             if (!worryBoardImageList.isEmpty()) {
                 for (S3Result s3Result : worryBoardImageList) {
-                    worryBoardImageService.uploadImage(s3Result.getImgUrl(), worryBoard);
+                    worryBoardImageService.uploadWorryImage(worryBoard, multipartFiles);
                 }
             }
         }
-        return "고민글 생성 완료";
+
+        return "고민글 수정 완료";
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
@@ -7,7 +7,6 @@ import com.example.mssaem_backend.domain.mbti.MbtiEnum;
 import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.domain.member.MemberRepository;
 import com.example.mssaem_backend.domain.member.dto.MemberResponseDto.MemberSimpleInfo;
-import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.GetWorriesReq;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.PatchWorryReq;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.PatchWorrySolvedReq;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.PostWorryReq;
@@ -111,20 +110,21 @@ public class WorryBoardService {
     }
 
     // mbti 필터링 조회
-    public PageResponseDto<List<GetWorriesRes>> findWorriesByMbti(GetWorriesReq getWorriesReq,
-        Boolean isSolved, int page, int size) {
+    public PageResponseDto<List<GetWorriesRes>> findWorriesByMbti(Boolean isSolved,
+        String strFromMbti,
+        String strToMbti,
+        int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
 
-        boolean isFromAll = getWorriesReq.getFromMbti().equals("ALL");
-        boolean isToAll = getWorriesReq.getToMbti().equals("ALL");
+        boolean isFromAll = strFromMbti.equals("ALL");
+        boolean isToAll = strToMbti.equals("ALL");
 
         // ALL인 경우에 mbti에는 null값이 들어감
-        MbtiEnum fromMbti = isFromAll ? null : MbtiEnum.valueOf(getWorriesReq.getFromMbti());
-        MbtiEnum toMbti = isToAll ? null : MbtiEnum.valueOf(getWorriesReq.getToMbti());
+        MbtiEnum fromMbti = isFromAll ? null : MbtiEnum.valueOf(strFromMbti);
+        MbtiEnum toMbti = isToAll ? null : MbtiEnum.valueOf(strToMbti);
 
         Page<WorryBoard> result = worryBoardRepository.findWorriesBySolvedAndBothMbtiAndStateTrue(
-            isSolved,
-            fromMbti, toMbti, pageable);
+            isSolved, fromMbti, toMbti, pageable);
 
         return new PageResponseDto<>(result.getNumber(), result.getTotalPages(),
             makeGetWorriesResForm(result));

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/dto/WorryBoardRequestDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/dto/WorryBoardRequestDto.java
@@ -1,7 +1,5 @@
 package com.example.mssaem_backend.domain.worryboard.dto;
 
-import com.example.mssaem_backend.domain.mbti.MbtiEnum;
-import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/dto/WorryBoardRequestDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/dto/WorryBoardRequestDto.java
@@ -21,7 +21,6 @@ public class WorryBoardRequestDto {
     @AllArgsConstructor
     public static class PatchWorrySolvedReq {
 
-        Long worryBoardId;
         Long worrySolverId; //해결한 사람 id
     }
 
@@ -40,7 +39,6 @@ public class WorryBoardRequestDto {
     @AllArgsConstructor
     public static class PatchWorryReq {
 
-        Long worryBoardId;
         String title;
         String content;
         MbtiEnum targetMbti;

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/dto/WorryBoardRequestDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/dto/WorryBoardRequestDto.java
@@ -1,5 +1,6 @@
 package com.example.mssaem_backend.domain.worryboard.dto;
 
+import com.example.mssaem_backend.domain.mbti.MbtiEnum;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,5 +22,12 @@ public class WorryBoardRequestDto {
         Long worrySolverId; //해결한 사람 id
     }
 
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PostWorryReq {
+        String title;
+        String content;
+        MbtiEnum targetMbti;
+    }
 }
-

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/dto/WorryBoardRequestDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/dto/WorryBoardRequestDto.java
@@ -10,15 +10,6 @@ public class WorryBoardRequestDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class GetWorriesReq {
-
-        String fromMbti;
-        String toMbti;
-    }
-
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
     public static class PatchWorrySolvedReq {
 
         Long worrySolverId; //해결한 사람 id

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/dto/WorryBoardRequestDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/dto/WorryBoardRequestDto.java
@@ -1,5 +1,7 @@
 package com.example.mssaem_backend.domain.worryboard.dto;
 
+import com.example.mssaem_backend.domain.mbti.MbtiEnum;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,4 +14,14 @@ public class WorryBoardRequestDto {
         String fromMbti;
         String toMbti;
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PatchWorrySolvedReq {
+        Long worryBoardId;
+        Long worrySolverId; //해결한 사람 id
+    }
+
 }
+

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/dto/WorryBoardRequestDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/dto/WorryBoardRequestDto.java
@@ -6,10 +6,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 public class WorryBoardRequestDto {
+
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
     public static class GetWorriesReq {
+
         String fromMbti;
         String toMbti;
     }
@@ -18,6 +20,7 @@ public class WorryBoardRequestDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class PatchWorrySolvedReq {
+
         Long worryBoardId;
         Long worrySolverId; //해결한 사람 id
     }
@@ -26,6 +29,18 @@ public class WorryBoardRequestDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class PostWorryReq {
+
+        String title;
+        String content;
+        MbtiEnum targetMbti;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PatchWorryReq {
+
+        Long worryBoardId;
         String title;
         String content;
         MbtiEnum targetMbti;

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/dto/WorryBoardResponseDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/dto/WorryBoardResponseDto.java
@@ -24,11 +24,12 @@ public class WorryBoardResponseDto {
         private String content;
         private String createdAt;
         private List<String> imgList;
-        private Boolean isAllowed;
+        private Boolean isEditAllowed;
+        private Boolean isChatAllowed;
 
         @Builder
         public GetWorryRes(WorryBoard worryBoard, List<String> imgList,
-            MemberSimpleInfo memberSimpleInfo, String createdAt, Boolean isAllowed) {
+            MemberSimpleInfo memberSimpleInfo, String createdAt, Boolean isEditAllowed, Boolean isChatAllowed) {
             this.worryBoardId = worryBoard.getId();
             this.memberSimpleInfo = memberSimpleInfo;
             this.targetMbti = worryBoard.getTargetMbti();
@@ -36,7 +37,8 @@ public class WorryBoardResponseDto {
             this.content = worryBoard.getContent();
             this.createdAt = createdAt;
             this.imgList = imgList;
-            this.isAllowed = isAllowed;
+            this.isEditAllowed = isEditAllowed;
+            this.isChatAllowed = isChatAllowed;
         }
     }
 

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/dto/WorryBoardResponseDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/dto/WorryBoardResponseDto.java
@@ -12,55 +12,69 @@ import lombok.NoArgsConstructor;
 
 public class WorryBoardResponseDto {
 
-  @Getter
-  @NoArgsConstructor
-  @AllArgsConstructor
-  public static class GetWorryRes {
-    private MemberSimpleInfo memberSimpleInfo;
-    private Long worryBoardId;
-    private MbtiEnum targetMbti;
-    private String title;
-    private String content;
-    private String createdAt;
-    private List<String> imgList;
-    private Boolean isAllowed;
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetWorryRes {
 
-    @Builder
-    public GetWorryRes(WorryBoard worryBoard, List<String> imgList,
-        MemberSimpleInfo memberSimpleInfo, String createdAt, Boolean isAllowed) {
-      this.worryBoardId = worryBoard.getId();
-      this.memberSimpleInfo = memberSimpleInfo;
-      this.targetMbti = worryBoard.getTargetMbti();
-      this.title = worryBoard.getTitle();
-      this.content = worryBoard.getContent();
-      this.createdAt = createdAt;
-      this.imgList = imgList;
-      this.isAllowed = isAllowed;
+        private MemberSimpleInfo memberSimpleInfo;
+        private Long worryBoardId;
+        private MbtiEnum targetMbti;
+        private String title;
+        private String content;
+        private String createdAt;
+        private List<String> imgList;
+        private Boolean isAllowed;
+
+        @Builder
+        public GetWorryRes(WorryBoard worryBoard, List<String> imgList,
+            MemberSimpleInfo memberSimpleInfo, String createdAt, Boolean isAllowed) {
+            this.worryBoardId = worryBoard.getId();
+            this.memberSimpleInfo = memberSimpleInfo;
+            this.targetMbti = worryBoard.getTargetMbti();
+            this.title = worryBoard.getTitle();
+            this.content = worryBoard.getContent();
+            this.createdAt = createdAt;
+            this.imgList = imgList;
+            this.isAllowed = isAllowed;
+        }
     }
-  }
 
-  @Getter
-  @AllArgsConstructor
-  @NoArgsConstructor
-  public static class GetWorriesRes {
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class GetWorriesRes {
 
-    private String title;
-    private String content;
-    private MbtiEnum memberMbti;
-    private MbtiEnum targetMbti;
-    private String createdDate;
-    private String imgUrl;
+        private String title;
+        private String content;
+        private MbtiEnum memberMbti;
+        private MbtiEnum targetMbti;
+        private String createdDate;
+        private String imgUrl;
 
-    @Builder
-    public GetWorriesRes(WorryBoard worryBoard, String imgUrl, String createdAt) {
-      this.title = worryBoard.getTitle();
-      this.content = worryBoard.getContent();
-      this.memberMbti = worryBoard.getMember().getMbti();
-      this.targetMbti = worryBoard.getTargetMbti();
-      this.createdDate = createdAt;
-      this.imgUrl = imgUrl;
+        @Builder
+        public GetWorriesRes(WorryBoard worryBoard, String imgUrl, String createdAt) {
+            this.title = worryBoard.getTitle();
+            this.content = worryBoard.getContent();
+            this.memberMbti = worryBoard.getMember().getMbti();
+            this.targetMbti = worryBoard.getTargetMbti();
+            this.createdDate = createdAt;
+            this.imgUrl = imgUrl;
+        }
     }
-  }
 
+    @Getter
+    @NoArgsConstructor
+    public static class PatchWorrySolvedRes {
+
+        private MemberSimpleInfo memberSimpleInfo;
+        private Long worryBoardId;
+
+        @Builder
+        public PatchWorrySolvedRes(MemberSimpleInfo memberSimpleInfo, Long worryBoardId) {
+            this.memberSimpleInfo = memberSimpleInfo;
+            this.worryBoardId = worryBoardId;
+        }
+    }
 }
 

--- a/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImage.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImage.java
@@ -4,6 +4,7 @@ import com.example.mssaem_backend.domain.worryboard.WorryBoard;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,4 +21,10 @@ public class WorryBoardImage{
     private WorryBoard worryBoard;
 
     private String imgUrl;
+
+    @Builder
+    public WorryBoardImage(WorryBoard worryBoard, String imgUrl) {
+        this.worryBoard = worryBoard;
+        this.imgUrl = imgUrl;
+    }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageRepository.java
@@ -6,8 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WorryBoardImageRepository extends JpaRepository<WorryBoardImage, Long> {
 
-  List<WorryBoardImage> findAllByWorryBoard(WorryBoard worryBoard);
+    List<WorryBoardImage> findAllByWorryBoard(WorryBoard worryBoard);
 
-  WorryBoardImage findTopByWorryBoardOrderById(WorryBoard worryBoard);
+    WorryBoardImage findTopByWorryBoardOrderById(WorryBoard worryBoard);
 
+    void deleteAllByWorryBoard(WorryBoard worryBoard);
 }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageService.java
@@ -1,17 +1,21 @@
 package com.example.mssaem_backend.domain.worryboardimage;
 
 import com.example.mssaem_backend.domain.worryboard.WorryBoard;
+import com.example.mssaem_backend.global.s3.S3Service;
+import com.example.mssaem_backend.global.s3.dto.S3Result;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Service
 public class WorryBoardImageService {
 
     private final WorryBoardImageRepository worryBoardImageRepository;
+    private final S3Service s3Service;
 
     //해당 고민글 이미지 url 리스트 가져오기
     public List<String> getImgUrls(WorryBoard worryBoard) {
@@ -35,12 +39,24 @@ public class WorryBoardImageService {
         return worryBoardImage.getImgUrl();
     }
 
-    //이미지 업로드
-    public void uploadImage(String worryBoardImageUrl, WorryBoard worryBoard) {
-        worryBoardImageRepository.save(
-            WorryBoardImage.builder().
-                imgUrl(worryBoardImageUrl)
-                .worryBoard(worryBoard).
-                build());
+    //worryBoardImage 저장
+    public void uploadWorryImage(WorryBoard worryBoard, List<MultipartFile> multipartFiles) {
+        //s3 저장 후 url리스트 가져오기
+        List<S3Result> s3ResultList = s3Service.uploadFile(multipartFiles);
+
+        //받은 url을 worryBoardImage로 저장
+        if (!s3ResultList.isEmpty()) {
+            for (S3Result s3Result : s3ResultList) {
+                worryBoardImageRepository.save(WorryBoardImage.builder()
+                    .worryBoard(worryBoard)
+                    .imgUrl(s3Result.getImgUrl())
+                    .build());
+            }
+        }
+    }
+
+    //worryBoardImage 삭제
+    public void deleteWorryImage(WorryBoard worryBoard) {
+        worryBoardImageRepository.findAllByWorryBoard(worryBoard);
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageService.java
@@ -35,12 +35,4 @@ public class WorryBoardImageService {
         }
         return worryBoardImage.getImgUrl();
     }
-
-    public String uploadImage(String worryBoardImageUrl, WorryBoard worryBoard) {
-        WorryBoardImage worryBoardImage = WorryBoardImage.builder()
-            .worryBoard(worryBoard)
-            .imgUrl(worryBoardImageUrl)
-            .build();
-        return "이미지 업로드 완료";
-    }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageService.java
@@ -62,7 +62,7 @@ public class WorryBoardImageService {
     }
 
     //worryBoardImage 삭제
-    public void deleteWorryImage(WorryBoard worryBoard, List<MultipartFile> multipartFiles) {
+    public void deleteWorryImage(WorryBoard worryBoard) {
         List<WorryBoardImage> worryBoardImages = worryBoardImageRepository.findAllByWorryBoard(
             worryBoard);
 

--- a/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageService.java
@@ -77,8 +77,5 @@ public class WorryBoardImageService {
 
         //해당 worryBoard에 존재하는 worryBoardImage 삭제
         worryBoardImageRepository.deleteAllByWorryBoard(worryBoard);
-
-        //이미지 저장 및 worryBoardImage 생성
-        uploadImage(worryBoard, multipartFiles);
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageService.java
@@ -11,25 +11,36 @@ import org.springframework.stereotype.Service;
 @Service
 public class WorryBoardImageService {
 
-  private final WorryBoardImageRepository worryBoardImageRepository;
+    private final WorryBoardImageRepository worryBoardImageRepository;
 
+    //해당 고민글 이미지 url 리스트 가져오기
+    public List<String> getImgUrls(WorryBoard worryBoard) {
+        List<WorryBoardImage> worryBoardImages = worryBoardImageRepository.findAllByWorryBoard(
+            worryBoard);
 
-  //해당 고민글 이미지 url 리스트 가져오기
-  public List<String> getImgUrls(WorryBoard worryBoard) {
-    List<WorryBoardImage> worryBoardImages = worryBoardImageRepository.findAllByWorryBoard(worryBoard);
-
-    if(worryBoardImages.isEmpty()) {
-      return Collections.singletonList("default");
+        if (worryBoardImages.isEmpty()) {
+            return Collections.singletonList("default");
+        }
+        return worryBoardImages.stream()
+            .map(WorryBoardImage::getImgUrl)
+            .collect(Collectors.toList());
     }
-    return worryBoardImages.stream()
-        .map(WorryBoardImage::getImgUrl)
-        .collect(Collectors.toList());
-  }
 
-  //해당 고민글 대표 이미지 가져오기
-  public String  getImgUrl(WorryBoard worryBoard) {
-    WorryBoardImage worryBoardImage = worryBoardImageRepository.findTopByWorryBoardOrderById(worryBoard);
-    if(worryBoardImage == null) return "default";
-    return  worryBoardImage.getImgUrl();
-  }
+    //해당 고민글 대표 이미지 가져오기
+    public String getImgUrl(WorryBoard worryBoard) {
+        WorryBoardImage worryBoardImage = worryBoardImageRepository.findTopByWorryBoardOrderById(
+            worryBoard);
+        if (worryBoardImage == null) {
+            return "default";
+        }
+        return worryBoardImage.getImgUrl();
+    }
+
+    public String uploadImage(String worryBoardImageUrl, WorryBoard worryBoard) {
+        WorryBoardImage worryBoardImage = WorryBoardImage.builder()
+            .worryBoard(worryBoard)
+            .imgUrl(worryBoardImageUrl)
+            .build();
+        return "이미지 업로드 완료";
+    }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageService.java
@@ -17,23 +17,6 @@ public class WorryBoardImageService {
     private final WorryBoardImageRepository worryBoardImageRepository;
     private final S3Service s3Service;
 
-    //이미지 s3 저장 후 worryBoardImage 생성
-    private void uploadImage(WorryBoard worryBoard, List<MultipartFile> multipartFiles) {
-        //s3 저장 후 url리스트 가져오기
-        List<S3Result> s3ResultList = s3Service.uploadFile(multipartFiles);
-
-        //반환된 url을 worryBoardImage로 저장
-        if (!s3ResultList.isEmpty()) {
-            for (S3Result s3Result : s3ResultList) {
-                worryBoardImageRepository.save(WorryBoardImage.builder()
-                    .worryBoard(worryBoard)
-                    .imgUrl(s3Result.getImgUrl())
-                    .build());
-            }
-        }
-    }
-
-
     //해당 고민글 이미지 url 리스트 가져오기
     public List<String> getImgUrls(WorryBoard worryBoard) {
         List<WorryBoardImage> worryBoardImages = worryBoardImageRepository.findAllByWorryBoard(
@@ -56,12 +39,24 @@ public class WorryBoardImageService {
         return worryBoardImage.getImgUrl();
     }
 
-    //worryBoardImage 저장
+    //이미지 s3 저장 후 worryBoardImage 생성
     public void saveWorryImage(WorryBoard worryBoard, List<MultipartFile> multipartFiles) {
-        uploadImage(worryBoard, multipartFiles);
+        //s3 저장 후 url리스트 가져오기
+        List<S3Result> s3ResultList = s3Service.uploadFile(multipartFiles);
+
+        //반환된 url을 worryBoardImage로 저장
+        if (!s3ResultList.isEmpty()) {
+            for (S3Result s3Result : s3ResultList) {
+                worryBoardImageRepository.save(WorryBoardImage.builder()
+                    .worryBoard(worryBoard)
+                    .imgUrl(s3Result.getImgUrl())
+                    .build());
+            }
+        }
     }
 
-    //worryBoardImage 삭제
+
+    //s3 이미지 삭제 후 worryBoardImage 삭제
     public void deleteWorryImage(WorryBoard worryBoard) {
         List<WorryBoardImage> worryBoardImages = worryBoardImageRepository.findAllByWorryBoard(
             worryBoard);

--- a/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageService.java
@@ -21,8 +21,7 @@ public class WorryBoardImageService {
         if (worryBoardImages.isEmpty()) {
             return Collections.singletonList("default");
         }
-        return worryBoardImages.stream()
-            .map(WorryBoardImage::getImgUrl)
+        return worryBoardImages.stream().map(WorryBoardImage::getImgUrl)
             .collect(Collectors.toList());
     }
 
@@ -34,5 +33,14 @@ public class WorryBoardImageService {
             return "default";
         }
         return worryBoardImage.getImgUrl();
+    }
+
+    //이미지 업로드
+    public void uploadImage(String worryBoardImageUrl, WorryBoard worryBoard) {
+        worryBoardImageRepository.save(
+            WorryBoardImage.builder().
+                imgUrl(worryBoardImageUrl)
+                .worryBoard(worryBoard).
+                build());
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageService.java
@@ -56,7 +56,20 @@ public class WorryBoardImageService {
     }
 
     //worryBoardImage 삭제
-    public void deleteWorryImage(WorryBoard worryBoard) {
-        worryBoardImageRepository.findAllByWorryBoard(worryBoard);
+    public void deleteWorryImage(WorryBoard worryBoard, List<MultipartFile> multipartFiles) {
+        List<WorryBoardImage> worryBoardImages = worryBoardImageRepository.findAllByWorryBoard(
+            worryBoard);
+
+        //해당 worryBoard에 존재하는 s3 파일 삭제
+        if (!worryBoardImages.isEmpty()) {
+            for (WorryBoardImage worryBoardImage : worryBoardImages) {
+                s3Service.deleteFile(
+                    s3Service.parseFileName(worryBoardImage.getImgUrl())
+                );
+            }
+        }
+
+        //해당 worryBoard에 존재하는 worryBoardImage 삭제
+        worryBoardImageRepository.deleteAllByWorryBoard(worryBoard);
     }
 }

--- a/src/test/java/com/example/mssaem_backend/domain/worryboard/WorryBoardControllerTest.java
+++ b/src/test/java/com/example/mssaem_backend/domain/worryboard/WorryBoardControllerTest.java
@@ -29,7 +29,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@TestInstance(Lifecycle.PER_CLASS)
 @SpringBootTest
 @AutoConfigureMockMvc
 class WorryBoardControllerTest {
@@ -59,9 +58,9 @@ class WorryBoardControllerTest {
     void beforeAll() {
         //member
         Member member1 = new Member(1L, "junsuck@naver.com", "heron", MbtiEnum.INFP, true,
-            "tokenExample", Role.ROLE_MANAGER, "1234", "1100", "example1", 0);
+            "tokenExample", Role.ROLE_MANAGER, "1234", "1100",  0);
         Member member2 = new Member(2L, "Jinro@naver.com", "Jinro", MbtiEnum.ENTJ, true,
-            "tokenExample", Role.ROLE_MANAGER, "1234", "1100", "example2", 0);
+            "tokenExample", Role.ROLE_MANAGER, "1234", "1100",  0);
 
         //worryBoard
         //해결 안된 고민
@@ -69,14 +68,12 @@ class WorryBoardControllerTest {
             .title("title1")
             .content("content1")
             .targetMbti(MbtiEnum.ESFJ)
-            .state(false)
             .member(member1)
             .build();
         WorryBoard worryBoard2 = WorryBoard.builder()
             .title("title2")
             .content("content2")
             .targetMbti(MbtiEnum.ENTP)
-            .state(false)
             .member(member1)
             .build();
         //해결이 된 고민
@@ -84,27 +81,22 @@ class WorryBoardControllerTest {
             .title("titleSolved1")
             .content("contentSolved1")
             .targetMbti(MbtiEnum.ENTJ)
-            .state(true)
             .member(member1)
             .build();
         WorryBoard worryBoardSolved2 = WorryBoard.builder()
             .title("titleSolved2")
             .content("contentSolved2")
             .targetMbti(MbtiEnum.ENTJ)
-            .state(true)
             .member(member1)
             .build();
 
-        worryBoardSolved1.setSolveMember(member2);
-        worryBoardSolved2.setSolveMember(member2);
-
         //worryBoardImage
-        WorryBoardImage worryBoardImage1 = new WorryBoardImage(1L, worryBoard1, "imgUrl1");
-        WorryBoardImage worryBoardImage2 = new WorryBoardImage(2L, worryBoard1, "imgUrl2");
-        WorryBoardImage worryBoardImage3 = new WorryBoardImage(3L, worryBoard1, "imgUrl3");
-        WorryBoardImage worryBoardImage4 = new WorryBoardImage(4L, worryBoard1, "imgUrl4");
-        WorryBoardImage worryBoardImage5 = new WorryBoardImage(5L, worryBoardSolved1, "imgUrl5");
-        WorryBoardImage worryBoardImage6 = new WorryBoardImage(6L, worryBoardSolved1, "imgUrl6");
+        WorryBoardImage worryBoardImage1 = new WorryBoardImage(worryBoard1, "imgUrl1");
+        WorryBoardImage worryBoardImage2 = new WorryBoardImage(worryBoard1, "imgUrl2");
+        WorryBoardImage worryBoardImage3 = new WorryBoardImage(worryBoard1, "imgUrl3");
+        WorryBoardImage worryBoardImage4 = new WorryBoardImage(worryBoard1, "imgUrl4");
+        WorryBoardImage worryBoardImage5 = new WorryBoardImage(worryBoardSolved1, "imgUrl5");
+        WorryBoardImage worryBoardImage6 = new WorryBoardImage(worryBoardSolved1, "imgUrl6");
 
         //badge
         Badge badge1 = new Badge(1L, "엠비티라노", member1, true);

--- a/src/test/java/com/example/mssaem_backend/domain/worryboard/WorryBoardControllerTest.java
+++ b/src/test/java/com/example/mssaem_backend/domain/worryboard/WorryBoardControllerTest.java
@@ -14,8 +14,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
## 요약

- 고민글 생성, 수정, 삭제, 완료 처리 API

## 상세 내용

- 생성, 수정, 삭제 모두 S3 관련 처리는 `WorryBoardImageService`로 처리를 넘겼습니다.

- **worryBoardImageService**
```java
    //이미지 s3 저장 후 worryBoardImage 생성
    public void saveWorryImage(WorryBoard worryBoard, List<MultipartFile> multipartFiles) {
        //s3 저장 후 url리스트 가져오기
        List<S3Result> s3ResultList = s3Service.uploadFile(multipartFiles);

        //반환된 url을 worryBoardImage로 저장
        if (!s3ResultList.isEmpty()) {
            for (S3Result s3Result : s3ResultList) {
                worryBoardImageRepository.save(WorryBoardImage.builder()
                    .worryBoard(worryBoard)
                    .imgUrl(s3Result.getImgUrl())
                    .build());
            }
        }
    }

    //worryBoardImage 삭제
    public void deleteWorryImage(WorryBoard worryBoard) {
        List<WorryBoardImage> worryBoardImages = worryBoardImageRepository.findAllByWorryBoard(
            worryBoard);

        //해당 worryBoard에 존재하는 s3 파일 삭제
        if (!worryBoardImages.isEmpty()) {
            for (WorryBoardImage worryBoardImage : worryBoardImages) {
                s3Service.deleteFile(
                    s3Service.parseFileName(worryBoardImage.getImgUrl())
                );
            }
        }

        //해당 worryBoard에 존재하는 worryBoardImage 삭제
        worryBoardImageRepository.deleteAllByWorryBoard(worryBoard);
    }
```

`saveWorryImage` : s3에 파일을 업로드 후 url리스트를 통해 worryBoardImage를 생성합니다.
`deleteWorryImage` : 해당 WorryBoard에 있는 s3 파일들을 삭제 후 worryBoardImage 엔티티 또한 삭제합니다.

WorryBoardService -> s3 처리 넘길 때
고민글 생성시 : `saveWorryImage` 만 사용
고민글 수정시 : `deleteWorryImage` 로 모두 제거 후 `saveWorryImage`사용
고민글 삭제시 : `deleteWorryImage` 만 사용

---

- **worryBoardService**

```java
      @Transactional
     // 고민 해결 완료
    public PatchWorrySolvedRes solveWorryBoard(Member currentMember, Long id,
        PatchWorrySolvedReq patchWorryReq) {
        WorryBoard worryBoard = worryBoardRepository.findById(id)
            .orElseThrow(() -> new BaseException(WorryBoardErrorCode.EMPTY_WORRY_BOARD));
        if (!currentMember.getId().equals(worryBoard.getMember().getId())) {
            throw new BaseException(MemberErrorCode.INVALID_MEMBER);
        }

        Member solveMember = memberRepository.findById(patchWorryReq.getWorrySolverId())
            .orElseThrow(() -> new BaseException(MemberErrorCode.EMPTY_MEMBER));
        // 고민글의 상태 바꾸기
        worryBoard.solveWorryBoard(solveMember);
        // 평가창에 뜰 memberSimpleInfo, worryBoard Id 반환
        return PatchWorrySolvedRes.builder()
            .memberSimpleInfo(
                new MemberSimpleInfo(
                    solveMember.getId(), solveMember.getNickName(),
                    solveMember.getMbti(),
                    badgeService.findRepresentativeBadgeByMember(solveMember),
                    solveMember.getProfileImageUrl())
            )
            .worryBoardId(id).build();
    }



 //고민글 생성
    public String createWorryBoard(Member currentMember, PostWorryReq postWorryReq,
        List<MultipartFile> multipartFiles) {
        //고민글 내용 저장
        WorryBoard worryBoard = WorryBoard.builder()
            .title(postWorryReq.getTitle())
            .content(postWorryReq.getContent())
            .targetMbti(postWorryReq.getTargetMbti())
            .member(currentMember)
            .build();
        worryBoardRepository.save(worryBoard);

        //S3 처리 worryBoardImageService에 전달
        if (multipartFiles != null) {
            worryBoardImageService.saveWorryImage(worryBoard, multipartFiles);
        }
        return "고민글 생성 완료";
    }

    //고민글 수정
    @Transactional
    public String modifyWorryBoard(Member currentMember, Long id, PatchWorryReq patchWorryReq,
        List<MultipartFile> multipartFiles) {
        //현재 멤버와 작성자 일치하는 지 확인
        WorryBoard worryBoard = worryBoardRepository.findById(id)
            .orElseThrow(() -> new BaseException(WorryBoardErrorCode.EMPTY_WORRY_BOARD));
        if (!currentMember.getId().equals(worryBoard.getMember().getId())) {
            throw new BaseException(MemberErrorCode.INVALID_MEMBER);
        }

        //worryBoard 수정하기
        worryBoard.modifyWorryBoard(
            patchWorryReq.getTitle(),
            patchWorryReq.getContent(),
            patchWorryReq.getTargetMbti()
        );

        //S3 처리 worryBoardImageService로 전달
        worryBoardImageService.deleteWorryImage(worryBoard);
        if (multipartFiles != null) {
            worryBoardImageService.saveWorryImage(worryBoard, multipartFiles);
        }
        return "고민글 수정 완료";
    }

    @Transactional
    //고민글 삭제
    public String deleteWorryBoard(Member currentMember, Long id) {
        //현재 멤버와 작성자 일치하는 지 확인
        WorryBoard worryBoard = worryBoardRepository.findById(id)
            .orElseThrow(() -> new BaseException(WorryBoardErrorCode.EMPTY_WORRY_BOARD));
        if (!currentMember.getId().equals(worryBoard.getMember().getId())) {
            throw new BaseException(MemberErrorCode.INVALID_MEMBER);
        }

        worryBoard.deleteWorryBoard();
        worryBoardImageService.deleteWorryImage(worryBoard);

        return "고민글 삭제 완료";
    }
```


---
- **WorryBoardRepository**
```java
Page<WorryBoard> findByIsSolvedAndStateTrueOrderByCreatedAtDesc(boolean isSolved, Pageable pageable);

    Page<WorryBoard> findByMemberIdAndStateTrueOrderByCreatedAtDesc(Long memberId, Pageable pageable);

    Page<WorryBoard> findBySolveMemberIdAndStateTrueOrderByCreatedAtDesc(Long memberId, Pageable pageable);

    List<WorryBoard> findTop7ByIsSolvedFalseAndStateTrueOrderByCreatedAtDesc();

    @Query("SELECT wb FROM WorryBoard wb WHERE wb.state = true AND wb.isSolved = :isSolved AND (:fromMbti IS NULL OR wb.member.mbti = :fromMbti) AND (:toMbti IS NULL OR wb.targetMbti = :toMbti) ORDER BY wb.createdAt DESC")
    Page<WorryBoard> findWorriesBySolvedAndBothMbtiAndStateTrue(
        @Param("isSolved") Boolean isSolved,
        @Param("fromMbti") MbtiEnum fromMbti,
        @Param("toMbti") MbtiEnum toMbti,
        Pageable pageable
    );

    @Query("SELECT wb.solveMember FROM WorryBoard wb WHERE wb.solvedAt >= :oneMonthAgo AND wb.state = true GROUP BY wb.solveMember.id HAVING COUNT(wb.solveMember.id) >= 1 ORDER BY COUNT(wb.solveMember.id) DESC, wb.solveMember.id")
    Page<Member> findSolveMemberWithMoreThanOneIdAndIsSolvedTrueAndStateTrue(
        @Param("oneMonthAgo") LocalDateTime oneMonthAgo, PageRequest pageRequest);
```
- 모든 쿼리에 엔티티 변경 사항 반영(state -> isSolved)
- 리스트 조회 시 생성일 기준 Desc정렬  추가
- 삭제된 글 필터링 위해 StateTrue 추가

---

## 질문 및 이외 사항

- WorryBoard 엔티티의 isSovled 자료형을 boolean에서 Boolean으로 변경(변수명에 is가 붙고 boolean형이면 쿼리 메소드 인식이 안돼요!!)

## 이슈 번호

- #11 
