### PR TITLE
Repository 리팩토링

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/badge/Badge.java
+++ b/src/main/java/com/example/mssaem_backend/domain/badge/Badge.java
@@ -10,13 +10,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Badge extends BaseTimeEntity {
 

--- a/src/main/java/com/example/mssaem_backend/domain/badge/BadgeRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/badge/BadgeRepository.java
@@ -3,8 +3,11 @@ package com.example.mssaem_backend.domain.badge;
 import com.example.mssaem_backend.domain.member.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BadgeRepository extends JpaRepository<Badge, Long> {
 
-    Optional<Badge> findBadgeByMemberAndStateTrue(Member member);
+    @Query("SELECT b.name FROM Badge b WHERE b.member = :member AND b.state = true")
+    Optional<String> findNameMemberAndStateTrue(@Param("member") Member member);
 }

--- a/src/main/java/com/example/mssaem_backend/domain/badge/BadgeService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/badge/BadgeService.java
@@ -12,7 +12,6 @@ public class BadgeService {
 
     //멤버의 대표 뱃지 가져오기
     public String findRepresentativeBadgeByMember(Member member) {
-        return badgeRepository.findBadgeByMemberAndStateTrue(member).orElse(new Badge())
-               .getName();
+        return badgeRepository.findNameMemberAndStateTrue(member).orElse(null);
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
@@ -1,13 +1,11 @@
 package com.example.mssaem_backend.domain.board;
 
-import com.example.mssaem_backend.domain.badge.Badge;
 import com.example.mssaem_backend.domain.badge.BadgeRepository;
 import com.example.mssaem_backend.domain.board.dto.BoardRequestDto.PatchBoardReq;
 import com.example.mssaem_backend.domain.board.dto.BoardRequestDto.PostBoardReq;
 import com.example.mssaem_backend.domain.board.dto.BoardResponseDto.BoardSimpleInfo;
 import com.example.mssaem_backend.domain.board.dto.BoardResponseDto.ThreeHotInfo;
 import com.example.mssaem_backend.domain.boardcomment.BoardCommentRepository;
-import com.example.mssaem_backend.domain.boardimage.BoardImage;
 import com.example.mssaem_backend.domain.boardimage.BoardImageRepository;
 import com.example.mssaem_backend.domain.boardimage.BoardImageService;
 import com.example.mssaem_backend.domain.discussion.Discussion;
@@ -70,10 +68,9 @@ public class BoardService {
         PageRequest pageRequest = PageRequest.of(0, 5);
         List<Board> boards =
             likeRepository.findBoardsWithMoreThanTenLikesInLastThreeDaysAndStateTrue(
-                    LocalDateTime.now().minusDays(3)
-                    , pageRequest
-                )
-                .stream()
+                    LocalDateTime.now().minusDays(3),
+                    pageRequest
+                ).stream()
                 .collect(Collectors.toList());
         if (!boards.isEmpty()) {
             boards.remove(0);
@@ -93,8 +90,7 @@ public class BoardService {
                     board.getId(),
                     board.getTitle(),
                     board.getContent(),
-                    boardImageRepository.findTopByBoardOrderById(board).orElse(new BoardImage())
-                        .getImageUrl(),
+                    boardImageRepository.findImageUrlByBoardOrderById(board).orElse(null),
                     board.getMbti(),
                     board.getLikeCount(),
                     boardCommentRepository.countByBoardAndStateTrue(board),
@@ -103,8 +99,7 @@ public class BoardService {
                         board.getMember().getId(),
                         board.getMember().getNickName(),
                         board.getMember().getDetailMbti(),
-                        badgeRepository.findBadgeByMemberAndStateTrue(board.getMember())
-                            .orElse(new Badge()).getName(),
+                        badgeRepository.findNameMemberAndStateTrue(board.getMember()).orElse(null),
                         board.getMember().getProfileImageUrl()
                     )
                 )

--- a/src/main/java/com/example/mssaem_backend/domain/boardimage/BoardImage.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardimage/BoardImage.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,7 +18,7 @@ import org.hibernate.annotations.DynamicInsert;
 @DynamicInsert
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class BoardImage extends BaseTimeEntity {
 

--- a/src/main/java/com/example/mssaem_backend/domain/boardimage/BoardImageRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardimage/BoardImageRepository.java
@@ -6,10 +6,13 @@ import java.util.Optional;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BoardImageRepository extends JpaRepository<BoardImage, Long> {
 
-    Optional<BoardImage> findTopByBoardOrderById(Board board);
+    @Query("SELECT bi.imageUrl FROM BoardImage bi WHERE bi.board = :board ORDER BY bi.id LIMIT 1")
+    Optional<String> findImageUrlByBoardOrderById(@Param("board") Board board);
 
     List<BoardImage> findAllByBoardId(Long id);
 

--- a/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionService.java
@@ -1,6 +1,5 @@
 package com.example.mssaem_backend.domain.discussion;
 
-import com.example.mssaem_backend.domain.badge.Badge;
 import com.example.mssaem_backend.domain.badge.BadgeRepository;
 import com.example.mssaem_backend.domain.discussion.dto.DiscussionResponseDto.DiscussionSimpleInfo;
 import com.example.mssaem_backend.domain.discussioncomment.DiscussionCommentRepository;
@@ -97,10 +96,7 @@ public class DiscussionService {
                         discussion.getMember().getId(),
                         discussion.getMember().getNickName(),
                         discussion.getMember().getDetailMbti(),
-                        badgeRepository.findBadgeByMemberAndStateTrue(
-                                discussion.getMember())
-                            .orElse(new Badge())
-                            .getName(),
+                        badgeRepository.findNameMemberAndStateTrue(discussion.getMember()).orElse(null),
                         discussion.getMember().getProfileImageUrl()
                     ),
                     selectedOptionIdx != -1

--- a/src/main/java/com/example/mssaem_backend/domain/like/LikeRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/like/LikeRepository.java
@@ -2,6 +2,7 @@ package com.example.mssaem_backend.domain.like;
 
 import com.example.mssaem_backend.domain.board.Board;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/example/mssaem_backend/domain/member/MemberService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/member/MemberService.java
@@ -1,6 +1,5 @@
 package com.example.mssaem_backend.domain.member;
 
-import com.example.mssaem_backend.domain.badge.Badge;
 import com.example.mssaem_backend.domain.badge.BadgeRepository;
 import com.example.mssaem_backend.domain.member.dto.MemberRequestDto.CheckNickName;
 import com.example.mssaem_backend.domain.member.dto.MemberRequestDto.RegisterMember;
@@ -114,9 +113,7 @@ public class MemberService {
                     solveMember.getId(),
                     solveMember.getNickName(),
                     solveMember.getDetailMbti(),
-                    badgeRepository.findBadgeByMemberAndStateTrue(solveMember)
-                        .orElse(new Badge())
-                        .getName(),
+                    badgeRepository.findNameMemberAndStateTrue(solveMember).orElse(null),
                     solveMember.getProfileImageUrl(),
                     solveMember.getIntroduction()
                 )


### PR DESCRIPTION
## 요약

- BadgeRepository와 BoardImageRepository의 메소드 결과값이 없을 때 빈 객체를 새로 만들지 않고 null로 반환

## 상세 내용
### BadgeRepository 
```java
    @Query("SELECT b.name FROM Badge b WHERE b.member = :member AND b.state = true")
    Optional<String> findNameMemberAndStateTrue(@Param("member") Member member);
```
### BoardImageRepository 
``` java
    @Query("SELECT bi.imageUrl FROM BoardImage bi WHERE bi.board = :board ORDER BY bi.id LIMIT 1")
    Optional<String> findImageUrlByBoardOrderById(@Param("board") Board board);
```
### Badge, BoardImage
- `@NoArgsConstructor`를 AccessLevel.PROTECTED로 설정 
### BadgeService, BoardService, DiscussionService, MemberService
- 수정된 메소드 반영 

## 이슈 번호

- #89
