### PR TITLE
카카오 소셜 로그인 API

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/member/MemberService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/member/MemberService.java
@@ -66,8 +66,8 @@ public class MemberService {
         String idToken = socialLoginToken.getIdToken();
         String email = "";
         switch (socialLoginType) {
-            case KAKAO -> email = kakaoLoginService.getEmail(idToken);
-            //case GOOGLE -> email =
+            case KAKAO -> email = kakaoLoginService.getEmail(kakaoLoginService.getAccessToken(idToken));
+            //case GOOGLE -> email = googleLoginService.getEmail(idToken);
             //case NAVER -> email =
         }
 

--- a/src/main/java/com/example/mssaem_backend/global/config/exception/errorCode/AuthErrorCode.java
+++ b/src/main/java/com/example/mssaem_backend/global/config/exception/errorCode/AuthErrorCode.java
@@ -13,7 +13,8 @@ public enum AuthErrorCode implements ErrorCode {
     EXPIRED_MEMBER_JWT("AUTH_003", "만료된 JWT입니다.", HttpStatus.UNAUTHORIZED),
     UNSUPPORTED_JWT("AUTH_004", "지원하지 않는 JWT입니다.", HttpStatus.UNAUTHORIZED),
     INVALID_ID_TOKEN("AUTH_005", "유효하지 않은 ID TOKEN입니다.", HttpStatus.BAD_REQUEST),
-    FAILED_APPLE_LOGIN("AUTH_006", "APPLE LOGIN에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    INVALID_ACCESS_TOKEN("AUTH_006", "유효하지 않은 ACCESS TOKEN입니다.", HttpStatus.BAD_REQUEST),
+    FAILED_SOCIAL_LOGIN("AUTH_007", "소셜 로그인에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
     private final String errorCode;
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/example/mssaem_backend/global/config/security/oauth/GoogleLoginService.java
+++ b/src/main/java/com/example/mssaem_backend/global/config/security/oauth/GoogleLoginService.java
@@ -1,0 +1,7 @@
+package com.example.mssaem_backend.global.config.security.oauth;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class GoogleLoginService {
+}

--- a/src/main/java/com/example/mssaem_backend/global/config/security/oauth/KakaoLoginService.java
+++ b/src/main/java/com/example/mssaem_backend/global/config/security/oauth/KakaoLoginService.java
@@ -2,19 +2,60 @@ package com.example.mssaem_backend.global.config.security.oauth;
 
 import com.example.mssaem_backend.global.config.exception.BaseException;
 import com.example.mssaem_backend.global.config.exception.errorCode.AuthErrorCode;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
 
 import javax.net.ssl.HttpsURLConnection;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.net.URL;
 
 @Service
 public class KakaoLoginService {
+
+    public String getAccessToken(String idToken) throws IOException {
+        String accessToken = "";
+        String reqUrl = "https://kauth.kakao.com/oauth/token";
+
+        URL url = new URL(reqUrl);
+        HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();
+        conn.setRequestMethod(HttpMethod.POST.name());
+        conn.setDoOutput(true);
+
+        // POST 요청에서 필요한 파라미터를 OutputStream을 통해 전송
+        BufferedWriter bufferedWriter = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream()));
+        String sb = "grant_type=authorization_code" +
+                "&client_id=0b193a8cee2b14d1a2c57470cb2d8e3b" + // REST_API_KEY
+                "&redirect_uri=http://localhost:3000/kakao/login" + // REDIRECT_URI
+                "&code=" + idToken;
+        bufferedWriter.write(sb);
+        bufferedWriter.flush();
+
+        if (conn.getResponseCode() >= 400) {
+            throw new BaseException(AuthErrorCode.INVALID_ID_TOKEN);
+        }
+
+        // 요청을 통해 얻은 데이터를 InputStreamReader을 통해 읽어 오기
+        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+        String line = "";
+        StringBuilder result = new StringBuilder();
+
+        while ((line = bufferedReader.readLine()) != null) {
+            result.append(line);
+        }
+        System.out.println("response body : " + result);
+
+        JsonElement element = new JsonParser().parse(result.toString());
+
+        accessToken = element.getAsJsonObject().get("access_token").getAsString();
+
+        bufferedReader.close();
+        bufferedWriter.close();
+
+        System.out.println("accessToken : " + accessToken);
+        return accessToken;
+    }
 
     public String getEmail(String accessToken) throws IOException {
         String reqUrl = "https://kapi.kakao.com/v2/user/me";
@@ -25,7 +66,7 @@ public class KakaoLoginService {
         conn.setRequestProperty("Authorization", " Bearer " + accessToken);
 
         if (conn.getResponseCode() >= 400) {
-            throw new BaseException(AuthErrorCode.INVALID_ID_TOKEN);
+            throw new BaseException(AuthErrorCode.INVALID_ACCESS_TOKEN);
         }
         BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
         String line;


### PR DESCRIPTION
## 요약

- 카카오 소셜 로그인 idToken을 통해 accessToken 받아오는 로직 추가

## 상세 내용

- 프론트에서 인가 토큰(idToken) 서버로 넘겨줌 -> 서버에서 idToken을 카카오서버에 전송하여 accessToken 가져옴 -> accessToken을 이용해 유저 정보 가져옴 

## 질문 및 이외 사항

- 

## 이슈 번호

- #13 
 