### PR TITLE
전체 게시판과 Mbti 카테고리 별 검색하기 API 하나로 병합 

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardController.java
@@ -127,27 +127,16 @@ public class BoardController {
     }
 
     /**
-     * 전체 게시판 검색하기
-     */
-    @GetMapping("/boards/search-all")
-    public ResponseEntity<PageResponseDto<List<BoardSimpleInfo>>> findBoardListByKeyword(
-        @RequestBody SearchReq searchReq,
-        @RequestParam int page,
-        @RequestParam int size) {
-        return ResponseEntity.ok(boardService.findBoardListByKeyword(searchReq, page, size));
-    }
-
-    /**
-     * Mbti 카테고리 별 검색하기
+     * 게시글 검색하기
      */
     @GetMapping("/boards/search")
     public ResponseEntity<PageResponseDto<List<BoardSimpleInfo>>> findBoardListByKeywordAndMbti(
         @RequestBody SearchReq searchReq,
-        @RequestParam MbtiEnum mbti,
+        @RequestParam String strMbti,
         @RequestParam int page,
         @RequestParam int size) {
         return ResponseEntity.ok(
-            boardService.findBoardListByKeywordAndMbti(searchReq, mbti, page, size));
+            boardService.findBoardListByKeywordAndMbti(searchReq, strMbti, page, size));
     }
 
 }

--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardRepository.java
@@ -17,26 +17,13 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     Page<Board> findAllByMemberIdAndStateIsTrue(Long memberId, Pageable pageable);
 
-    // 전체 게시판 검색하기
+    // 검색하기
     @Query("SELECT b FROM Board b WHERE"
         + "(    (:type = 0 AND (LOWER(b.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(b.content) LIKE LOWER(CONCAT('%', :keyword, '%'))))"
         + " OR (:type = 1 AND LOWER(b.title) LIKE LOWER(CONCAT('%', :keyword, '%')))"
         + " OR (:type = 2 AND LOWER(b.content) LIKE LOWER(CONCAT('%', :keyword, '%')))"
         + " OR (:type = 3 AND LOWER(b.member.nickName) LIKE LOWER(CONCAT('%', :keyword, '%'))) )"
-        + " AND b.state = true ORDER BY b.createdAt DESC ")
-    Page<Board> searchByType(
-        @Param("type") int type,
-        @Param("keyword") String keyword,
-        Pageable pageable);
-
-
-    // Mbti 카테고리 별 검색하기
-    @Query("SELECT b FROM Board b WHERE"
-        + "(    (:type = 0 AND (LOWER(b.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(b.content) LIKE LOWER(CONCAT('%', :keyword, '%'))))"
-        + " OR (:type = 1 AND LOWER(b.title) LIKE LOWER(CONCAT('%', :keyword, '%')))"
-        + " OR (:type = 2 AND LOWER(b.content) LIKE LOWER(CONCAT('%', :keyword, '%')))"
-        + " OR (:type = 3 AND LOWER(b.member.nickName) LIKE LOWER(CONCAT('%', :keyword, '%'))) )"
-        + " AND b.state = true AND b.mbti = :mbti ORDER BY b.createdAt DESC ")
+        + " AND b.state = true AND (:mbti IS NULL OR b.mbti = :mbti) ORDER BY b.createdAt DESC ")
     Page<Board> searchByTypeAndMbti(
         @Param("type") int type,
         @Param("keyword") String keyword,

--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
@@ -136,7 +136,7 @@ public class BoardService {
         Board board = boardRepository.findById(boardId)
             .orElseThrow(() -> new BaseException(BoardErrorCode.EMPTY_BOARD));
         //현재 로그인한 멤버와 해당 게시글의 멤버가 같은지 확인
-        if(isMatch(member, board.getMember())) {
+        if (isMatch(member, board.getMember())) {
             board.modifyBoard(patchBoardReq.getTitle(), patchBoardReq.getContent(),
                 patchBoardReq.getMbti());
             //현재 저장된 이미지 삭제
@@ -266,29 +266,12 @@ public class BoardService {
             .build();
     }
 
-    // 전체 게시판 검색하기
-    public PageResponseDto<List<BoardSimpleInfo>> findBoardListByKeyword(
-        SearchReq searchReq, int page, int size) {
-        PageRequest pageRequest = PageRequest.of(page, size);
-
-        Page<Board> boards = boardRepository.searchByType(searchReq.getType(),
-            searchReq.getKeyword(), pageRequest);
-
-        return new PageResponseDto<>(
-            boards.getNumber(),
-            boards.getTotalPages(),
-            setBoardSimpleInfo(
-                boards
-                    .stream()
-                    .collect(Collectors.toList()),
-                3)
-        );
-    }
-
     // Mbti 카테고리 별 검색하기
     public PageResponseDto<List<BoardSimpleInfo>> findBoardListByKeywordAndMbti(
-        SearchReq searchReq,MbtiEnum mbti, int page, int size) {
+        SearchReq searchReq, String strMbti, int page, int size) {
         PageRequest pageRequest = PageRequest.of(page, size);
+
+        MbtiEnum mbti = strMbti.equals("ALL") ? null : MbtiEnum.valueOf(strMbti);
 
         Page<Board> boards = boardRepository.searchByTypeAndMbti(searchReq.getType(),
             searchReq.getKeyword(), mbti, pageRequest);


### PR DESCRIPTION
## 요약

- 전체 게시판 검색하기 API와 Mbti 카테고리 별 검색하기 API를 하나로 합침

## 상세 내용
### BoardController
```java
    @GetMapping("/boards/search")
    public ResponseEntity<PageResponseDto<List<BoardSimpleInfo>>> findBoardListByKeywordAndMbti(
        @RequestBody SearchReq searchReq,
        @RequestParam String strMbti,
        @RequestParam int page,
        @RequestParam int size) {
        return ResponseEntity.ok(
            boardService.findBoardListByKeywordAndMbti(searchReq, strMbti, page, size));
    }
```
- 전체 게시판 검색하기 uri 삭제 
### BoardRepository 
```java
    // 검색하기
    @Query("SELECT b FROM Board b WHERE"
        + "(    (:type = 0 AND (LOWER(b.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(b.content) LIKE LOWER(CONCAT('%', :keyword, '%'))))"
        + " OR (:type = 1 AND LOWER(b.title) LIKE LOWER(CONCAT('%', :keyword, '%')))"
        + " OR (:type = 2 AND LOWER(b.content) LIKE LOWER(CONCAT('%', :keyword, '%')))"
        + " OR (:type = 3 AND LOWER(b.member.nickName) LIKE LOWER(CONCAT('%', :keyword, '%'))) )"
        + " AND b.state = true AND (:mbti IS NULL OR b.mbti = :mbti) ORDER BY b.createdAt DESC ")
```
- mbti 값이 NULL이 아닐 때만 WHERE 조건에 추가해줘서 전체 게시판과 Mbit 카테고리 검색 기능을 메소드 하나로 해결
### BoardService
- 전체 게시판 검색하기 관련 메소드 삭제
- 파라미터로 받은 strMbti가 ALL이면 MbtiEnum에 해당하는 값이 없으므로 null로 처리, strMbti가 ALL이 아니면 MbtiEnum에 해당하는 값으로 매핑
## 질문 및 이외 사항

- 

## 이슈 번호

- #81
