### PR TITLE
게시글 생성 시 썸네일 저장 API

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/board/Board.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/Board.java
@@ -78,4 +78,8 @@ public class Board extends BaseTimeEntity {
     public void deleteBoard() {
         this.state = false;
     }
+
+    public void changeThumbnail(String thumbnail) {
+        this.thumbnail = thumbnail;
+    }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/board/Board.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/Board.java
@@ -3,9 +3,20 @@ package com.example.mssaem_backend.domain.board;
 import com.example.mssaem_backend.domain.mbti.MbtiEnum;
 import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.global.common.BaseTimeEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 
@@ -50,11 +61,12 @@ public class Board extends BaseTimeEntity {
     private Long commentCount;
 
     @Builder
-    public Board(String title, String content, MbtiEnum mbti, Member member) {
+    public Board(String title, String content, MbtiEnum mbti, Member member, String thumbnail) {
         this.title = title;
         this.content = content;
         this.mbti = mbti;
         this.member = member;
+        this.thumbnail = thumbnail;
     }
 
     public void modifyBoard(String title, String content, MbtiEnum mbti) {

--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
@@ -120,19 +120,28 @@ public class BoardService {
 
     public String createBoard(Member member, PostBoardReq postBoardReq,
         List<MultipartFile> multipartFiles) {
-        //먼저 S3에 이미지 저장
-        List<S3Result> result = s3Service.uploadFile(multipartFiles);
+        if (multipartFiles != null) { //이미지가 있는 경우
+            //먼저 S3에 이미지 저장
+            List<S3Result> result = s3Service.uploadFile(multipartFiles);
 
-        Board board = Board.builder()
-            .title(postBoardReq.getTitle())
-            .content(postBoardReq.getContent())
-            .mbti(postBoardReq.getMbti())
-            .member(member)
-            .thumbnail(result.get(0).getImgUrl()) //받아온 이미지 중 첫번째 사진 썸네일
-            .build();
-        boardRepository.save(board);
-        if (multipartFiles != null) {
+            Board board = Board.builder()
+                .title(postBoardReq.getTitle())
+                .content(postBoardReq.getContent())
+                .mbti(postBoardReq.getMbti())
+                .member(member)
+                .thumbnail(result.get(0).getImgUrl()) //받아온 이미지 중 첫번째 사진 썸네일
+                .build();
+            boardRepository.save(board);
             boardImageService.uploadBoardImage(board, result);
+        } else { //이미지가 없는 경우
+            Board board = Board.builder()
+                .title(postBoardReq.getTitle())
+                .content(postBoardReq.getContent())
+                .mbti(postBoardReq.getMbti())
+                .member(member)
+                .thumbnail(null) // 이미지 없으면 썸네일 null
+                .build();
+            boardRepository.save(board);
         }
         return "게시글 생성 완료";
     }

--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
@@ -137,7 +137,7 @@ public class BoardService {
         Board board = boardRepository.findById(boardId)
             .orElseThrow(() -> new BaseException(BoardErrorCode.EMPTY_BOARD));
         //현재 로그인한 멤버와 해당 게시글의 멤버가 같은지 확인
-        if(isMatch(member, board.getMember())) {
+        if (isMatch(member, board.getMember())) {
             board.modifyBoard(patchBoardReq.getTitle(), patchBoardReq.getContent(),
                 patchBoardReq.getMbti());
             //현재 저장된 이미지 삭제
@@ -248,6 +248,8 @@ public class BoardService {
         Member member = board.getMember();
         //게시글 수정, 삭제 권한 확인
         Boolean isAllowed = (isMatch(viewer, member));
+        //게시글 좋아요 눌렀는지 확인
+        Boolean isLiked = likeRepository.existsLikeByMemberAndStateIsTrueAndBoard(viewer, board);
 
         return GetBoardRes.builder()
             .memberSimpleInfo(
@@ -264,6 +266,7 @@ public class BoardService {
             .createdAt(calculateTime(board.getCreatedAt(), 2))
             .commentCount(boardCommentRepository.countByBoardAndStateTrue(board))
             .isAllowed(isAllowed)
+            .isLiked(isLiked)
             .build();
     }
 

--- a/src/main/java/com/example/mssaem_backend/domain/board/dto/BoardResponseDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/dto/BoardResponseDto.java
@@ -87,11 +87,12 @@ public class BoardResponseDto {
         private String createdAt;
         private Long likeCount;
         private Long commentCount;
-        private Boolean isAllowed;
+        private Boolean isAllowed; //게시글 수정 삭제 권한 확인
+        private Boolean isLiked; //게시글 좋아요 눌렀는지 확인
 
         @Builder
         public GetBoardRes(MemberSimpleInfo memberSimpleInfo, Board board, List<String> imgUrlList,
-            String createdAt, Long commentCount, Boolean isAllowed) {
+            String createdAt, Long commentCount, Boolean isAllowed, Boolean isLiked) {
             this.memberSimpleInfo = memberSimpleInfo;
             this.boardId = board.getId();
             this.title = board.getTitle();
@@ -101,6 +102,7 @@ public class BoardResponseDto {
             this.likeCount = board.getLikeCount();
             this.commentCount = commentCount;
             this.isAllowed = isAllowed;
+            this.isLiked = isLiked;
         }
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/boardimage/BoardImage.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardimage/BoardImage.java
@@ -32,11 +32,8 @@ public class BoardImage extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Board board;
 
-    public BoardImage(String imageUrl){
-        this.imageUrl = imageUrl;
-    }
-
-    public void setBoard(Board board) {
+    public BoardImage(Board board, String imageUrl) {
         this.board = board;
+        this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/boardimage/BoardImageService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardimage/BoardImageService.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Service
@@ -32,10 +31,8 @@ public class BoardImageService {
         boardImageRepository.deleteAllByBoard(board);
     }
 
-    public void uploadBoardImage(Board board, List<MultipartFile> multipartFiles) {
-        //multipartFiles 로 부터 파일 받아오기
-        List<S3Result> boardImageList = s3Service.uploadFile(multipartFiles);
-        //이미지 저장
+    public void uploadBoardImage(Board board, List<S3Result> boardImageList) {
+        //S3에 먼저 저장된 리스트를 받아와 DB에 이미지 저장
         if (!boardImageList.isEmpty()) {
             for (S3Result s3Result : boardImageList) {
                 uploadImage(s3Result.getImgUrl(), board);

--- a/src/main/java/com/example/mssaem_backend/domain/boardimage/BoardImageService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardimage/BoardImageService.java
@@ -40,6 +40,7 @@ public class BoardImageService {
         boardImageRepository.saveAll(boardImages);
 
         return s3ResultList.isEmpty() ? null : s3ResultList.get(0).getImgUrl();
+
     }
 
     public void deleteBoardImage(Board board) {

--- a/src/main/java/com/example/mssaem_backend/domain/like/LikeRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/like/LikeRepository.java
@@ -1,8 +1,8 @@
 package com.example.mssaem_backend.domain.like;
 
 import com.example.mssaem_backend.domain.board.Board;
+import com.example.mssaem_backend.domain.member.Member;
 import java.time.LocalDateTime;
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,5 +13,8 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
 
     // 3일 동안 10개 이상 좋아요를 받은 게시물들을 3일 동안 받은 좋아요수 기준으로 내림차순 정렬
     @Query(value = "SELECT l.board FROM Like l WHERE l.createdAt >= :threeDaysAgo AND l.board.state = true AND l.state = true GROUP BY l.board HAVING COUNT(l.board.id) >= 1 ORDER BY COUNT(l.board.id) DESC")
-    Page<Board> findBoardsWithMoreThanTenLikesInLastThreeDaysAndStateTrue(@Param("threeDaysAgo") LocalDateTime threeDaysAgo, PageRequest pageRequest);
+    Page<Board> findBoardsWithMoreThanTenLikesInLastThreeDaysAndStateTrue(
+        @Param("threeDaysAgo") LocalDateTime threeDaysAgo, PageRequest pageRequest);
+
+    Boolean existsLikeByMemberAndStateIsTrueAndBoard(Member member, Board board);
 }


### PR DESCRIPTION
## 요약

- Board Entity 변경에 따른 게시글 생성 시 썸네일 저장 API 구현

## 상세 내용

- Board Entity 에 thumbnail 과 commentCount 필드 값이 추가되어, `setBoardSimpleInfo()` 를 변경
- `게시글 생성시 게시글 만들고 이미지 저장` 하던 기존 방식 -> `이미지 먼저 S3에 저장 후 썸네일을 받아와 게시글 생성`으로 변경

## 질문 및 이외 사항

- `createBoard()` 에서 Builder를 사용해 게시글 생성 시 , `thumbnail(result.get(0).getImgUrl()` 을 통해 받아온 이미지 중 첫번째 파일을 썸네일로 지정하였습니다. 이 부분에서 더 좋은 방법이 있을까요? 

## 이슈 번호

- close #111 
