### PR TITLE
게시글 이미지 업로드 API

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardController.java
@@ -22,7 +22,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @RestController
@@ -62,8 +61,8 @@ public class BoardController {
     @PostMapping("/member/boards")
     public ResponseEntity<String> createBoard(@CurrentMember Member member,
         @RequestPart(value = "postBoardReq") PostBoardReq postBoardReq,
-        @RequestPart(value = "image", required = false) List<MultipartFile> multipartFiles) {
-        return ResponseEntity.ok(boardService.createBoard(member, postBoardReq, multipartFiles));
+        @RequestPart(value = "image", required = false) List<String> imgUrls) {
+        return ResponseEntity.ok(boardService.createBoard(member, postBoardReq, imgUrls));
     }
 
     /**
@@ -73,9 +72,9 @@ public class BoardController {
     public ResponseEntity<String> modifyBoard(@CurrentMember Member member,
         @RequestPart(value = "patchBoardReq") PatchBoardReq patchBoardReq,
         @PathVariable(value = "id") Long id,
-        @RequestPart(value = "image", required = false) List<MultipartFile> multipartFiles) {
+        @RequestPart(value = "image", required = false) List<String> imgUrls) {
         return ResponseEntity.ok(
-            boardService.modifyBoard(member, patchBoardReq, id, multipartFiles));
+            boardService.modifyBoard(member, patchBoardReq, id, imgUrls));
     }
 
     /**

--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
@@ -34,7 +34,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Service
@@ -115,7 +114,7 @@ public class BoardService {
 
     @Transactional
     public String createBoard(Member member, PostBoardReq postBoardReq,
-        List<MultipartFile> multipartFiles) {
+        List<String> imgUrls) {
 
         Board board = Board.builder()
             .title(postBoardReq.getTitle())
@@ -125,8 +124,8 @@ public class BoardService {
             .thumbnail(null)
             .build();
 
-        if (multipartFiles != null) {
-            String thumbnail = boardImageService.uploadBoardImage(board, multipartFiles);
+        if (imgUrls != null) {
+            String thumbnail = boardImageService.uploadBoardImageUrl(board, imgUrls);
             board.changeThumbnail(thumbnail);
         }
         boardRepository.save(board);
@@ -135,7 +134,7 @@ public class BoardService {
 
     @Transactional
     public String modifyBoard(Member member, PatchBoardReq patchBoardReq, Long boardId,
-        List<MultipartFile> multipartFiles) {
+        List<String> imgUrls) {
         Board board = boardRepository.findById(boardId)
             .orElseThrow(() -> new BaseException(BoardErrorCode.EMPTY_BOARD));
         //현재 로그인한 멤버와 해당 게시글의 멤버가 같은지 확인
@@ -145,9 +144,9 @@ public class BoardService {
             //현재 저장된 이미지 삭제
             boardImageService.deleteBoardImage(board);
             //새로운 이미지 업로드
-            if (multipartFiles != null) {
-                //이미지 S3에 먼저 저장
-                boardImageService.uploadBoardImage(board, multipartFiles);
+            if (imgUrls != null) {
+                //이미지 DB에 저장
+                boardImageService.uploadBoardImageUrl(board, imgUrls);
             }
             return "게시글 수정 완료";
         } else {

--- a/src/main/java/com/example/mssaem_backend/domain/board/dto/BoardRequestDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/dto/BoardRequestDto.java
@@ -15,7 +15,6 @@ public class BoardRequestDto {
         private String title;
         private String content;
         private MbtiEnum mbti;
-        private Long memberId;
     }
 
     @Getter

--- a/src/main/java/com/example/mssaem_backend/domain/boardimage/BoardImageController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardimage/BoardImageController.java
@@ -1,9 +1,25 @@
 package com.example.mssaem_backend.domain.boardimage;
 
+import com.example.mssaem_backend.domain.member.Member;
+import com.example.mssaem_backend.global.config.security.auth.CurrentMember;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @RestController
 public class BoardImageController {
+
+    private final BoardImageService boardImageService;
+
+
+    //게시글 생성 시 파일 업로드 : 파일 하나 받아서 S3에 저장 후 url 반환
+    @PostMapping("/member/boards/files")
+    public ResponseEntity<String> uploadFiles(@CurrentMember Member member,
+        @RequestPart(value = "image", required = false) MultipartFile multipartFile) {
+        return ResponseEntity.ok(boardImageService.uploadFile(multipartFile));
+    }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/boardimage/BoardImageService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardimage/BoardImageService.java
@@ -2,7 +2,6 @@ package com.example.mssaem_backend.domain.boardimage;
 
 import com.example.mssaem_backend.domain.board.Board;
 import com.example.mssaem_backend.global.s3.S3Service;
-import com.example.mssaem_backend.global.s3.dto.S3Result;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -26,23 +25,6 @@ public class BoardImageService {
         boardImageRepository.deleteAllByBoard(board);
     }
 
-    public String uploadBoardImage(Board board, List<MultipartFile> multipartFiles) {
-        //S3에 먼저 저장된 리스트를 받아와 DB에 이미지 저장
-        List<S3Result> s3ResultList = s3Service.uploadFile(multipartFiles);
-
-        List<BoardImage> boardImages = new ArrayList<>();
-
-        if (!s3ResultList.isEmpty()) {
-            for (S3Result s3Result : s3ResultList) {
-                boardImages.add(new BoardImage(board, s3Result.getImgUrl()));
-            }
-        }
-        boardImageRepository.saveAll(boardImages);
-
-        return s3ResultList.isEmpty() ? null : s3ResultList.get(0).getImgUrl();
-
-    }
-
     public void deleteBoardImage(Board board) {
         //현재 DB에 저장된 이미지 불러오기
         List<BoardImage> dbBoardImageList = loadImage(board.getId());
@@ -64,5 +46,24 @@ public class BoardImageService {
         return boardImageList.stream()
             .map(BoardImage::getImageUrl)
             .collect(Collectors.toList());
+    }
+
+    //이미지 S3에 저장 후 해당 파일에 대한 url 바로 반환
+    public String uploadFile(MultipartFile multipartFile) {
+        return s3Service.uploadImage(multipartFile);
+    }
+
+    //전달받은 imgUrl 리스트 DB에 저장
+    public String uploadBoardImageUrl(Board board, List<String> imgUrls) {
+        List<BoardImage> boardImages = new ArrayList<>();
+
+        if (!imgUrls.isEmpty()) {
+            for (String result : imgUrls) {
+                boardImages.add(new BoardImage(board, result));
+            }
+        }
+        boardImageRepository.saveAll(boardImages);
+
+        return imgUrls.isEmpty() ? null : imgUrls.get(0);
     }
 }


### PR DESCRIPTION
## 요약

- 게시글 이미지 업로드 방식 변경

## 상세 내용

- 이미지 업로드 방식 변경 : 게시글 내용 json 업로드 api 와 한 파일 업로드 후 url 반환 api 따로 구현
### BoardController
- `createBoard()` : `List<String> imgUrls` 을 받아와서 전달

### BoardService
- `createBoard()` : `boardImageService.uploadBoardImageUrl()` 을 통해 DB에 저장

### BoardImageController
- `uploadFiles()` : `MultipartFile multipartFile` 을 받아와서 전달. 프론트에서 파일 하나씩 업로드가 가능하여 MultipartFile 로 받아옴

### BoardImageService
- `uploadBoardImageUrl()` : `boardImageService.uploadFile(multipartFile)` 을 통해 S3에 파일 저장

### S3 Service
- `uploadImage()` : 파일 하나만 받아 S3에 저장 후 url 반환

## 질문 및 이외 사항
- 테스트는 제대로 되었는데, 피드백 부탁드리겠습니다!

## 이슈 번호

- close #117 
