### PR TITLE
Fix : 게시글 수정 시 썸네일 변경 수정 및 게시글 상세 조회시 MBTI 추가

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
@@ -146,7 +146,9 @@ public class BoardService {
             //새로운 이미지 업로드
             if (imgUrls != null) {
                 //이미지 DB에 저장
-                boardImageService.uploadBoardImageUrl(board, imgUrls);
+                board.changeThumbnail(boardImageService.uploadBoardImageUrl(board, imgUrls));
+            } else {
+                board.changeThumbnail(null); //게시글 수정 시 이미지 없으면 다시 썸네일 제거
             }
             return "게시글 수정 완료";
         } else {

--- a/src/main/java/com/example/mssaem_backend/domain/board/dto/BoardResponseDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/dto/BoardResponseDto.java
@@ -89,6 +89,7 @@ public class BoardResponseDto {
         private Long commentCount;
         private Boolean isAllowed; //게시글 수정 삭제 권한 확인
         private Boolean isLiked; //게시글 좋아요 눌렀는지 확인
+        private MbtiEnum boardMbti; //게시글 MBTI
 
         @Builder
         public GetBoardRes(MemberSimpleInfo memberSimpleInfo, Board board, List<String> imgUrlList,
@@ -103,6 +104,7 @@ public class BoardResponseDto {
             this.commentCount = commentCount;
             this.isAllowed = isAllowed;
             this.isLiked = isLiked;
+            this.boardMbti = board.getMbti();
         }
     }
 }


### PR DESCRIPTION
## 요약

- 게시글 수정 API 에서 썸네일 변경 방식 수정 / 게시글 상세 조회시 MBTI 추가

## 상세 내용

- 게시글 상세 조회시 해당 게시글 MBTI 명시
- 게시글 수정 시 이미지가 없다면 `board.changeThumbnail(null)` 을 통해 썸네일 제거

## 질문 및 이외 사항

- 

## 이슈 번호

- #117 
