### PR TITLE
토론 참여하기 API

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/discussion/Discussion.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussion/Discussion.java
@@ -67,7 +67,7 @@ public class Discussion extends BaseTimeEntity {
         this.state = false;
     }
 
-    public void plusCount() {
+    public void increaseCount() {
         this.participantCount +=1;
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/discussion/Discussion.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussion/Discussion.java
@@ -66,4 +66,8 @@ public class Discussion extends BaseTimeEntity {
     public void deleteDiscussion() {
         this.state = false;
     }
+
+    public void plusCount() {
+        this.participantCount +=1;
+    }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionController.java
@@ -2,7 +2,6 @@ package com.example.mssaem_backend.domain.discussion;
 
 import com.example.mssaem_backend.domain.discussion.dto.DiscussionRequestDto.DiscussionReq;
 import com.example.mssaem_backend.domain.discussion.dto.DiscussionResponseDto.DiscussionSimpleInfo;
-import com.example.mssaem_backend.domain.discussionoption.DiscussionOption;
 import com.example.mssaem_backend.domain.discussionoption.dto.DiscussionOptionResponseDto.DiscussionOptionSelectedInfo;
 import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.domain.search.dto.SearchRequestDto.SearchReq;
@@ -11,7 +10,6 @@ import com.example.mssaem_backend.global.config.security.auth.CurrentMember;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;

--- a/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionController.java
@@ -2,6 +2,8 @@ package com.example.mssaem_backend.domain.discussion;
 
 import com.example.mssaem_backend.domain.discussion.dto.DiscussionRequestDto.DiscussionReq;
 import com.example.mssaem_backend.domain.discussion.dto.DiscussionResponseDto.DiscussionSimpleInfo;
+import com.example.mssaem_backend.domain.discussionoption.DiscussionOption;
+import com.example.mssaem_backend.domain.discussionoption.dto.DiscussionOptionResponseDto.DiscussionOptionSelectedInfo;
 import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.domain.search.dto.SearchRequestDto.SearchReq;
 import com.example.mssaem_backend.global.common.dto.PageResponseDto;
@@ -9,6 +11,7 @@ import com.example.mssaem_backend.global.config.security.auth.CurrentMember;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -86,5 +89,17 @@ public class DiscussionController {
         @PathVariable Long id) {
         return ResponseEntity.ok(
             discussionService.deleteDiscussion(member, id));
+    }
+
+    /**
+     * 토론글 참여하기
+     */
+    @PostMapping("/member/discussions/{discussionId}/discussion-options/{discussionOptionId}")
+    public ResponseEntity<List<DiscussionOptionSelectedInfo>> selectDiscussion(@CurrentMember Member member,
+        @PathVariable Long discussionId,
+        @PathVariable Long discussionOptionId
+    ) {
+        return ResponseEntity.ok(
+            discussionService.participateDiscussion(member, discussionId, discussionOptionId));
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionService.java
@@ -285,7 +285,7 @@ public class DiscussionService {
                 .build();
 
             //discussion의 count수 증가
-            discussion.plusCount();
+            discussion.increaseCount();
             discussionOptionSelectedRepository.save(discussionOptionSelected);
         }
 
@@ -302,6 +302,8 @@ public class DiscussionService {
             boolean isOptionSelectExsist = false;
             for(int i =0 ; i< discussionOptionSelects.size(); i++) {
                 Long id = discussionOptionSelects.get(i).getDiscussionOption().getId();
+                String content = discussionOptionSelects.get(i).getDiscussionOption().getContent();
+                System.out.println(content);
                 if(id.equals(discussionOptionId)) {
                     isOptionSelectExsist = true;
                 }
@@ -325,13 +327,12 @@ public class DiscussionService {
             }
 
             //이전에 선택한 option과 optionSelected count 감소
-            beforeDiscussionOption.minusCount();
-            System.out.println(discussionOptionSelects.get(beforeSelectedIdx).getDiscussionOption().getId());
+            beforeDiscussionOption.decreaseCount();
             discussionOptionSelects.get(beforeSelectedIdx).changeUnselected();
         }
 
         //option count수 증가
-        discussionOption.plusCount();
+        discussionOption.increaseCount();
 
         //해당 토론의 참여율 계산해서 반환
         return setDiscussionOptionSelectedInfo(discussion.getParticipantCount(), discussionOptions, selectIdx);

--- a/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionService.java
@@ -256,66 +256,84 @@ public class DiscussionService {
 
     //토론글 참여하기
     @Transactional
-    public List<DiscussionOptionSelectedInfo> participateDiscussion(Member member, Long discussionId, Long discussionOptionId) {
+    public List<DiscussionOptionSelectedInfo> participateDiscussion(Member member,
+        Long discussionId, Long discussionOptionId) {
         Discussion discussion = discussionRepository.findById(discussionId)
             .orElseThrow(() -> new BaseException(DiscussionErrorCode.EMPTY_DISCUSSION));
-        DiscussionOption discussionOption = discussionOptionRepository.findById(discussionOptionId)
-            .orElseThrow(() -> new BaseException(DiscussionErrorCode.EMPTY_DISCUSSION_OPTION));
+        List<DiscussionOption> discussionOptions = discussionOptionRepository.findDiscussionOptionByDiscussion(
+            discussion);
 
-        //첫 참여인지 변경인지 확인
-        DiscussionOptionSelected discussionOptionSelected =
-            discussionOptionSelectedRepository.findByDiscussionAndMemberAndStateTrue(discussion,
-                member);
+        //선택할 option 가져오기
+        int selectIdx = 0;
+        for(DiscussionOption discussionOption : discussionOptions) {
+            if(discussionOption.getId().equals(discussionOptionId))  {
+                break;
+            }
+            selectIdx++;
+        }
+
+        DiscussionOption discussionOption = discussionOptions.get(selectIdx);
+
+        //첫 참여라면 -1 아니면 이전 선택 option idx반환
+        int checkSelectedIdx = getSelectedOptionIdx(member, discussionOptions);
 
         //첫 참여라면
-        if (discussionOptionSelected == null) {
-            DiscussionOptionSelected newDiscussionOptionSelected = DiscussionOptionSelected.builder()
+        if (checkSelectedIdx == -1) {
+            DiscussionOptionSelected discussionOptionSelected = DiscussionOptionSelected.builder()
                 .discussionOption(discussionOption)
                 .member(member)
                 .build();
 
-
-            //discussion과 count수 증가
+            //discussion의 count수 증가
             discussion.plusCount();
-            discussionOptionSelectedRepository.save(newDiscussionOptionSelected);
+            discussionOptionSelectedRepository.save(discussionOptionSelected);
+        }
 
-        } else {
-            //이전에 선택했던 옵션과 optionSelected
-            DiscussionOption beforeDiscussionOption = discussionOptionSelectedRepository.findDiscussionOptionByDiscussionAndMemberAndStateTrue(
-                discussion, member);
-            DiscussionOptionSelected beforeDiscussionOptionSelected = discussionOptionSelectedRepository.findDiscussionOptionSelectedByMemberAndDiscussionOptionAndStateTrue(
-                member, beforeDiscussionOption);
+        //첫 참여가 아니라면 (선택한 옵션이 있다면)
+        else {
+            //이전에 선택했던 옵션과 optionSelected 불러오기
+            DiscussionOption beforeDiscussionOption = discussionOptions.get(checkSelectedIdx);
+            List<DiscussionOptionSelected> discussionOptionSelects = discussionOptionSelectedRepository.findAllByMemberAndDiscussionOrderByOptionIdAsc(
+                member, discussion);
 
-            // 이전 변경으로 인해 discussionOptionSelected가 false상태로 있는지 확인
-            DiscussionOptionSelected newDiscussionOptionSelected1 =
-                discussionOptionSelectedRepository.findDiscussionOptionSelectedByMemberAndDiscussionOptionAndStateTrue(
-                    member, discussionOption);
+            //현재 선택한 option에 대해 optionSeleted가 존재하는지 확인
+            //&& 직전 선택한 beforeOptionSelected idx값도 확인
+            int beforeSelectedIdx = 0;
+            boolean isOptionSelectExsist = false;
+            for(int i =0 ; i< discussionOptionSelects.size(); i++) {
+                Long id = discussionOptionSelects.get(i).getDiscussionOption().getId();
+                if(id.equals(discussionOptionId)) {
+                    isOptionSelectExsist = true;
+                }
+                if(id.equals(beforeDiscussionOption.getId())) {
+                    beforeSelectedIdx = i;
+                }
+            }
 
-            if (newDiscussionOptionSelected1 != null) {
-                newDiscussionOptionSelected1.changeSelected();
-            } else {
-                // discussionOptionSelected가 없다면
-                DiscussionOptionSelected newDiscussionOptionSelected2 = DiscussionOptionSelected.builder()
+            // 이전에 선택했었던 option으로 선택하는 경우
+            if (isOptionSelectExsist) {
+                discussionOptionSelects.get(selectIdx).changeSelected();
+            }
+            //이전에 선택하지 않았던 option으로 선택하는 경우
+            else {
+                DiscussionOptionSelected newDiscussionOptionSelected = DiscussionOptionSelected.builder()
                     .discussionOption(discussionOption)
                     .member(member)
                     .build();
 
-                discussionOptionSelectedRepository.save(newDiscussionOptionSelected2);
+                discussionOptionSelectedRepository.save(newDiscussionOptionSelected);
             }
 
             //이전에 선택한 option과 optionSelected count 감소
             beforeDiscussionOption.minusCount();
-            beforeDiscussionOptionSelected.changeUnselected();
+            System.out.println(discussionOptionSelects.get(beforeSelectedIdx).getDiscussionOption().getId());
+            discussionOptionSelects.get(beforeSelectedIdx).changeUnselected();
         }
 
         //option count수 증가
         discussionOption.plusCount();
 
         //해당 토론의 참여율 계산해서 반환
-        List<Discussion> discussions = new ArrayList<>();
-        discussions.add(discussion);
-        List<DiscussionOption> discussionOptions = discussionOptionRepository.findDiscussionOptionByDiscussion(discussion);
-        int selectedOptionIdx = getSelectedOptionIdx(member, discussionOptions);
-        return setDiscussionOptionSelectedInfo(discussion.getParticipantCount(), discussionOptions, selectedOptionIdx);
+        return setDiscussionOptionSelectedInfo(discussion.getParticipantCount(), discussionOptions, selectIdx);
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/discussionoption/DiscussionOption.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussionoption/DiscussionOption.java
@@ -38,4 +38,12 @@ public class DiscussionOption extends BaseTimeEntity {
         this.imgUrl = imgUrl;
         this.discussion = discussion;
     }
+
+    public void plusCount() {
+        this.selectCount += 1;
+    }
+
+    public void minusCount() {
+        this.selectCount -= 1;
+    }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/discussionoption/DiscussionOption.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussionoption/DiscussionOption.java
@@ -39,11 +39,11 @@ public class DiscussionOption extends BaseTimeEntity {
         this.discussion = discussion;
     }
 
-    public void plusCount() {
+    public void increaseCount() {
         this.selectCount += 1;
     }
 
-    public void minusCount() {
+    public void decreaseCount() {
         this.selectCount -= 1;
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/discussionoptionselected/DiscussionOptionSelected.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussionoptionselected/DiscussionOptionSelected.java
@@ -1,6 +1,7 @@
 package com.example.mssaem_backend.domain.discussionoptionselected;
 
 import com.example.mssaem_backend.domain.discussionoption.DiscussionOption;
+import com.example.mssaem_backend.domain.discussionoption.DiscussionOptionService;
 import com.example.mssaem_backend.domain.member.Member;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
@@ -33,4 +35,18 @@ public class DiscussionOptionSelected {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
+
+    @Builder
+    DiscussionOptionSelected(DiscussionOption discussionOption, Member member) {
+        this.discussionOption = discussionOption;
+        this.member = member;
+    }
+
+    public void changeSelected() {
+        this.state = true;
+    }
+
+    public void changeUnselected() {
+        this.state = false;
+    }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/discussionoptionselected/DiscussionOptionSelected.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussionoptionselected/DiscussionOptionSelected.java
@@ -1,7 +1,6 @@
 package com.example.mssaem_backend.domain.discussionoptionselected;
 
 import com.example.mssaem_backend.domain.discussionoption.DiscussionOption;
-import com.example.mssaem_backend.domain.discussionoption.DiscussionOptionService;
 import com.example.mssaem_backend.domain.member.Member;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -14,7 +13,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 
 @DynamicInsert

--- a/src/main/java/com/example/mssaem_backend/domain/discussionoptionselected/DiscussionOptionSelectedRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussionoptionselected/DiscussionOptionSelectedRepository.java
@@ -3,6 +3,7 @@ package com.example.mssaem_backend.domain.discussionoptionselected;
 import com.example.mssaem_backend.domain.discussion.Discussion;
 import com.example.mssaem_backend.domain.discussionoption.DiscussionOption;
 import com.example.mssaem_backend.domain.member.Member;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,18 +11,21 @@ import org.springframework.data.repository.query.Param;
 public interface DiscussionOptionSelectedRepository extends
     JpaRepository<DiscussionOptionSelected, Long> {
 
-    DiscussionOptionSelected findDiscussionOptionSelectedByMemberAndDiscussionOptionAndStateTrue(
+    DiscussionOptionSelected findDiscussionOptionSelectedByMemberAndDiscussionOptionAndStateFalse(
         Member member, DiscussionOption discussionOption);
 
-    @Query("SELECT dos FROM DiscussionOptionSelected dos "
-        + "WHERE dos.discussionOption.discussion = :discussion " + "AND dos.member = :member "
-        + "AND dos.state = true")
-    DiscussionOptionSelected findByDiscussionAndMemberAndStateTrue(
-        @Param("discussion") Discussion discussion, @Param("member") Member member);
+    DiscussionOptionSelected findDiscussionOptionSelectedByMemberAndDiscussionOptionAndStateTrue(
+        Member member, DiscussionOption beforeDiscussionOption);
 
     @Query("SELECT dos.discussionOption FROM DiscussionOptionSelected dos "
         + "WHERE dos.discussionOption.discussion = :discussion " + "AND dos.member = :member "
         + "AND dos.state = true")
     DiscussionOption findDiscussionOptionByDiscussionAndMemberAndStateTrue(
         @Param("discussion") Discussion discussion, @Param("member") Member member);
+
+    @Query("SELECT dos FROM DiscussionOptionSelected dos "
+        + "JOIN dos.discussionOption option "
+        + "WHERE dos.member = :member "
+        + "AND option.discussion = :discussion ORDER BY option.id ASC")
+    List<DiscussionOptionSelected> findAllByMemberAndDiscussionOrderByOptionIdAsc(@Param("member") Member member, @Param("discussion") Discussion discussion);
 }

--- a/src/main/java/com/example/mssaem_backend/domain/discussionoptionselected/DiscussionOptionSelectedRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussionoptionselected/DiscussionOptionSelectedRepository.java
@@ -1,12 +1,27 @@
 package com.example.mssaem_backend.domain.discussionoptionselected;
 
+import com.example.mssaem_backend.domain.discussion.Discussion;
 import com.example.mssaem_backend.domain.discussionoption.DiscussionOption;
 import com.example.mssaem_backend.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface DiscussionOptionSelectedRepository extends
     JpaRepository<DiscussionOptionSelected, Long> {
 
     DiscussionOptionSelected findDiscussionOptionSelectedByMemberAndDiscussionOptionAndStateTrue(
         Member member, DiscussionOption discussionOption);
+
+    @Query("SELECT dos FROM DiscussionOptionSelected dos "
+        + "WHERE dos.discussionOption.discussion = :discussion " + "AND dos.member = :member "
+        + "AND dos.state = true")
+    DiscussionOptionSelected findByDiscussionAndMemberAndStateTrue(
+        @Param("discussion") Discussion discussion, @Param("member") Member member);
+
+    @Query("SELECT dos.discussionOption FROM DiscussionOptionSelected dos "
+        + "WHERE dos.discussionOption.discussion = :discussion " + "AND dos.member = :member "
+        + "AND dos.state = true")
+    DiscussionOption findDiscussionOptionByDiscussionAndMemberAndStateTrue(
+        @Param("discussion") Discussion discussion, @Param("member") Member member);
 }

--- a/src/main/java/com/example/mssaem_backend/domain/discussionoptionselected/DiscussionOptionSelectedRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussionoptionselected/DiscussionOptionSelectedRepository.java
@@ -11,17 +11,8 @@ import org.springframework.data.repository.query.Param;
 public interface DiscussionOptionSelectedRepository extends
     JpaRepository<DiscussionOptionSelected, Long> {
 
-    DiscussionOptionSelected findDiscussionOptionSelectedByMemberAndDiscussionOptionAndStateFalse(
-        Member member, DiscussionOption discussionOption);
-
     DiscussionOptionSelected findDiscussionOptionSelectedByMemberAndDiscussionOptionAndStateTrue(
         Member member, DiscussionOption beforeDiscussionOption);
-
-    @Query("SELECT dos.discussionOption FROM DiscussionOptionSelected dos "
-        + "WHERE dos.discussionOption.discussion = :discussion " + "AND dos.member = :member "
-        + "AND dos.state = true")
-    DiscussionOption findDiscussionOptionByDiscussionAndMemberAndStateTrue(
-        @Param("discussion") Discussion discussion, @Param("member") Member member);
 
     @Query("SELECT dos FROM DiscussionOptionSelected dos "
         + "JOIN dos.discussionOption option "

--- a/src/main/java/com/example/mssaem_backend/global/config/exception/errorCode/DiscussionErrorCode.java
+++ b/src/main/java/com/example/mssaem_backend/global/config/exception/errorCode/DiscussionErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum DiscussionErrorCode implements ErrorCode {
     EMPTY_DISCUSSION("DISCUSSION_001", "존재하지 않는 토론글입니다.", HttpStatus.CONFLICT),
+    EMPTY_DISCUSSION_OPTION("DISCUSSION_002", "존재하지 않는 옵션입니다.", HttpStatus.CONFLICT)
     ;
 
     private final String errorCode;


### PR DESCRIPTION
## 요약

- 토론 참여하기

## 상세 내용

1. 토론은 `로그인한 유저`만 참여 가능,
2. `손절한다`를 선택한 유저는 다른 선택지 `봐준다`를 고를 수 있지만 `손절한다`를 다시 눌러 취소는 불가능
3. Option선택 시 해당 Member와 해당 Option을 갖는 optionSelected 생성, 만약 선택지를 변경 시 state를 false로 변경 

크게 두 가지의 경우를 고려했습니다.
사용자가 토론을 아예 처음 참여하는 경우와 이미 참여 후 선택지를 변경하는 경우

- **토론을 처음 참여하는 경우** 
1. `discussionOptionSelected` 생성
2. `discussion`의 particpant 증가
3. 선택한 `option`의 selectCount 증가

---

- **선택지를 변경하는 경우** 

이때도 또 두 가지의 경우가 있습니다.

a. 이전에 선택했었던 `option` 으로 다시 선택하는 경우
b. 이전에 선택하지 않았던 `option` 으로 선택하는 경우

a의 경우에는 이미 해당 `option`으로 state가 false 인`discussionOptionSelected`가 있기 때문에 changeSelected() 상태 변경
b의 경우에는 `discussionOptionSelected` 새로 생성

1. changeSelected() / discussionOptionSelected 새로 생성
2. 직전 선택한 `beforeOption`의 selectCount 감소
3. `discussionOptionSelected` changeUnselected로 상태 변경
4. 선택한 option의 selectCount 증가

참여율 계산 후 반환은 `율이`코드를 이용했습니다~!

## 질문 및 이외 사항

- 쿼리를 최대한 줄이기 위해 `option`과 `optionSelected`를 모두 리스트로 가져왔습니다. 쿼리 더 줄일 수 있는 방법이 있을까요,,,? 

## 이슈 번호

- close #33 
