### PR TITLE
특정 멤버별 게시판 댓글 조회 API

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentController.java
@@ -30,7 +30,7 @@ public class BoardCommentController {
         return ResponseEntity.ok(
             boardCommentService.findBoardCommentListByBoardId(member, boardId, page, size));
     }
-  
+
     //게시글 상세 조회시 베스트 댓글 3개 조회
     @GetMapping("/boards/{boardId}/comments/best")
     public ResponseEntity<List<BoardCommentSimpleInfo>> findBoardCommentBestListByBoardId(
@@ -61,6 +61,15 @@ public class BoardCommentController {
         @PathVariable(value = "commentId") Long commentId) {
         return ResponseEntity.ok(
             boardCommentService.deleteBoardComment(member, boardId, commentId));
+    }
+
+    //특정 멤버별 게시글 댓글 전체 조회
+    @GetMapping("/boards/comments")
+    public ResponseEntity<PageResponseDto<List<BoardCommentSimpleInfo>>> findBoardCommentListByMemberId(
+        @RequestParam(value = "memberId") Long memberId, @RequestParam(value = "page") int page,
+        @RequestParam(value = "size") int size) {
+        return ResponseEntity.ok(
+            boardCommentService.findBoardCommentListByMemberId(memberId, page, size));
     }
 
 }

--- a/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentController.java
@@ -2,6 +2,7 @@ package com.example.mssaem_backend.domain.boardcomment;
 
 import com.example.mssaem_backend.domain.boardcomment.dto.BoardCommentRequestDto.PostBoardCommentReq;
 import com.example.mssaem_backend.domain.boardcomment.dto.BoardCommentResponseDto.BoardCommentSimpleInfo;
+import com.example.mssaem_backend.domain.boardcomment.dto.BoardCommentResponseDto.BoardCommentSimpleInfoByMember;
 import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.global.common.dto.PageResponseDto;
 import com.example.mssaem_backend.global.config.security.auth.CurrentMember;
@@ -65,7 +66,7 @@ public class BoardCommentController {
 
     //특정 멤버별 게시글 댓글 전체 조회
     @GetMapping("/boards/comments")
-    public ResponseEntity<PageResponseDto<List<BoardCommentSimpleInfo>>> findBoardCommentListByMemberId(
+    public ResponseEntity<PageResponseDto<List<BoardCommentSimpleInfoByMember>>> findBoardCommentListByMemberId(
         @RequestParam(value = "memberId") Long memberId, @RequestParam(value = "page") int page,
         @RequestParam(value = "size") int size) {
         return ResponseEntity.ok(

--- a/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentController.java
@@ -68,9 +68,9 @@ public class BoardCommentController {
     @GetMapping("/boards/comments")
     public ResponseEntity<PageResponseDto<List<BoardCommentSimpleInfoByMember>>> findBoardCommentListByMemberId(
         @RequestParam(value = "memberId") Long memberId, @RequestParam(value = "page") int page,
-        @RequestParam(value = "size") int size) {
+        @RequestParam(value = "size") int size, @CurrentMember Member member) {
         return ResponseEntity.ok(
-            boardCommentService.findBoardCommentListByMemberId(memberId, page, size));
+            boardCommentService.findBoardCommentListByMemberId(memberId, page, size, member));
     }
 
 }

--- a/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentRepository.java
@@ -1,15 +1,13 @@
 package com.example.mssaem_backend.domain.boardcomment;
 
 import com.example.mssaem_backend.domain.board.Board;
+import com.example.mssaem_backend.domain.member.Member;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import java.util.List;
-
-import com.example.mssaem_backend.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.data.repository.query.Param;
 
 public interface BoardCommentRepository extends JpaRepository<BoardComment, Long> {
@@ -28,5 +26,7 @@ public interface BoardCommentRepository extends JpaRepository<BoardComment, Long
     Boolean existsBoardCommentById(Long id);
 
     BoardComment findByIdAndBoardIdAndStateIsTrue(Long id, Long boardId);
-  
+
+    Page<BoardComment> findAllByMemberIdAndStateIsTrue(Long memberId, Pageable pageable);
+
 }

--- a/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentService.java
@@ -111,7 +111,7 @@ public class BoardCommentService {
         }
         return boardComment.isState();
     }
-  
+
     // 좋아요 수 10개 이상으로 베스트 댓글 3개 조회
     public List<BoardCommentSimpleInfo> findBoardCommentBestListByBoardId(Member viewer,
         Long boardId) {
@@ -122,5 +122,21 @@ public class BoardCommentService {
 
         return setBoardCommentSimpleInfo(boardCommentList, viewer);
     }
-      
+
+    public PageResponseDto<List<BoardCommentSimpleInfo>> findBoardCommentListByMemberId(
+        Long memberId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<BoardComment> result = boardCommentRepository.findAllByMemberIdAndStateIsTrue(memberId,
+            pageable);
+
+        return new PageResponseDto<>(
+            result.getNumber(),
+            result.getTotalPages(),
+            setBoardCommentSimpleInfo(
+                result
+                    .stream()
+                    .collect(Collectors.toList()), null)
+        );
+    }
+
 }

--- a/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentService.java
@@ -46,7 +46,7 @@ public class BoardCommentService {
                     .boardComment(boardComment)
                     .createdAt(calculateTime(boardComment.getCreatedAt(), 3))
                     .isAllowed(isMatch(viewer,
-                        boardComment.getMember())) //해당 게시글을 보는 viewer 와 해당 댓글의 작성자와 같은지 확인
+                        boardComment.getMember())) //해당 댓글을 보는 viewer 와 해당 댓글의 작성자와 같은지 확인
                     .isLiked(
                         boardCommentLikeRepository.existsBoardCommentLikeByMemberAndStateIsTrueAndBoardCommentId(
                             boardComment.getMember(), boardComment.getId())) //댓글 좋아요 눌렀는지 안눌렀는지 확인
@@ -155,7 +155,7 @@ public class BoardCommentService {
 
     // 특정 멤버별 댓글 조회를 위한 매핑
     public List<BoardCommentSimpleInfoByMember> setBoardCommentSimpleInfoByBoard(
-        List<BoardComment> boardComments) {
+        List<BoardComment> boardComments, Member viewer) {
         List<BoardCommentSimpleInfoByMember> boardCommentSimpleInfoList = new ArrayList<>();
 
         for (BoardComment boardComment : boardComments) {
@@ -164,6 +164,11 @@ public class BoardCommentService {
                     .boardId(boardComment.getBoard().getId())
                     .boardComment(boardComment)
                     .createdAt(calculateTime(boardComment.getCreatedAt(), 3))
+                    .isAllowed(isMatch(viewer,
+                        boardComment.getMember())) //해당 댓글 보는 viewer 와 해당 댓글의 작성자와 같은지 확인
+                    .isLiked(
+                        boardCommentLikeRepository.existsBoardCommentLikeByMemberAndStateIsTrueAndBoardCommentId(
+                            boardComment.getMember(), boardComment.getId())) //댓글 좋아요 눌렀는지 안눌렀는지 확인
                     .memberSimpleInfo(
                         new MemberSimpleInfo(
                             boardComment.getMember().getId(),
@@ -180,7 +185,7 @@ public class BoardCommentService {
 
     //특정 멤버별 댓글 조회
     public PageResponseDto<List<BoardCommentSimpleInfoByMember>> findBoardCommentListByMemberId(
-        Long memberId, int page, int size) {
+        Long memberId, int page, int size, Member viewer) {
         Pageable pageable = PageRequest.of(page, size);
         Page<BoardComment> result = boardCommentRepository.findAllByMemberIdAndStateIsTrue(memberId,
             pageable);
@@ -191,7 +196,7 @@ public class BoardCommentService {
             setBoardCommentSimpleInfoByBoard(
                 result
                     .stream()
-                    .collect(Collectors.toList()))
+                    .collect(Collectors.toList()), viewer)
         );
     }
 

--- a/src/main/java/com/example/mssaem_backend/domain/boardcomment/dto/BoardCommentResponseDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardcomment/dto/BoardCommentResponseDto.java
@@ -20,7 +20,7 @@ public class BoardCommentResponseDto {
         private Integer parentId;
         private String createdAt;
         private Boolean isLiked; // 댓글 좋아요 눌렀는지 확인
-        private Boolean isAllowed; //댓글 또는 신고를 위한 내 댓글인지 확인
+        private Boolean isAllowed; //삭제 또는 신고를 위한 내 댓글인지 확인
         private MemberSimpleInfo memberSimpleInfo;
 
         @Builder
@@ -34,6 +34,32 @@ public class BoardCommentResponseDto {
             this.createdAt = createdAt;
             this.isAllowed = isAllowed;
             this.isLiked = isLiked;
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class BoardCommentSimpleInfoByMember {
+
+        private Long boardId;
+        private Long commentId;
+        private String Content;
+        private Long likeCount;
+        private Integer parentId;
+        private String createdAt;
+        private MemberSimpleInfo memberSimpleInfo;
+
+        @Builder
+        public BoardCommentSimpleInfoByMember(MemberSimpleInfo memberSimpleInfo, BoardComment boardComment,
+            String createdAt , Long boardId) {
+            this.boardId = boardId;
+            this.commentId = boardComment.getId();
+            this.Content = boardComment.getContent();
+            this.likeCount = boardComment.getLikeCount();
+            this.parentId = boardComment.getParentId();
+            this.memberSimpleInfo = memberSimpleInfo;
+            this.createdAt = createdAt;
         }
     }
 

--- a/src/main/java/com/example/mssaem_backend/domain/boardcomment/dto/BoardCommentResponseDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardcomment/dto/BoardCommentResponseDto.java
@@ -25,7 +25,7 @@ public class BoardCommentResponseDto {
 
         @Builder
         public BoardCommentSimpleInfo(MemberSimpleInfo memberSimpleInfo, BoardComment boardComment,
-            String createdAt , Boolean isAllowed , Boolean isLiked) {
+            String createdAt, Boolean isAllowed, Boolean isLiked) {
             this.commentId = boardComment.getId();
             this.Content = boardComment.getContent();
             this.likeCount = boardComment.getLikeCount();
@@ -48,11 +48,14 @@ public class BoardCommentResponseDto {
         private Long likeCount;
         private Integer parentId;
         private String createdAt;
+        private Boolean isLiked; // 댓글 좋아요 눌렀는지 확인
+        private Boolean isAllowed; //삭제 또는 신고를 위한 내 댓글인지 확인
         private MemberSimpleInfo memberSimpleInfo;
 
         @Builder
-        public BoardCommentSimpleInfoByMember(MemberSimpleInfo memberSimpleInfo, BoardComment boardComment,
-            String createdAt , Long boardId) {
+        public BoardCommentSimpleInfoByMember(MemberSimpleInfo memberSimpleInfo,
+            BoardComment boardComment, String createdAt, Long boardId, Boolean isAllowed,
+            Boolean isLiked) {
             this.boardId = boardId;
             this.commentId = boardComment.getId();
             this.Content = boardComment.getContent();
@@ -60,6 +63,8 @@ public class BoardCommentResponseDto {
             this.parentId = boardComment.getParentId();
             this.memberSimpleInfo = memberSimpleInfo;
             this.createdAt = createdAt;
+            this.isAllowed = isAllowed;
+            this.isLiked = isLiked;
         }
     }
 


### PR DESCRIPTION
## 요약

- 특정 멤버별 게시판 댓글을 모두 조회 합니다. 

## 상세 내용

### BoardCommentService
- `findBoardCommentListByMemberId()` : 해당 MemberId 에 대한 모든 댓글 list를 출력합니다.

### BoardCommentRepository
- `findAllByMemberIdAndStateIsTrue()` : 해당 멤버에 대한 모든 댓글 리스트를 받아옵니다.

## 질문 및 이외 사항

- 일단 게시글 댓글 조회와 토론글 댓글 조회를 분리해서 구현해보았습니다! 일단 이렇게 각각 구현하고 수정할까 합니다.

## 이슈 번호

- close #106 
