### PR TITLE
토큰 갱신과 네이버 소셜 로그인 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,10 @@ dependencies {
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.13'
     implementation 'io.awspring.cloud:spring-cloud-aws:2.4.2'
 
+    // web client
+    implementation 'org.projectreactor:reactor-spring:1.0.1.RELEASE'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux:3.1.2'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/example/mssaem_backend/domain/member/MemberController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/member/MemberController.java
@@ -88,5 +88,12 @@ public class MemberController {
         return new ResponseEntity<>(memberService.getProfile(memberId), HttpStatus.OK);
     }
 
+    /**
+     * [PATCH] 로그인 토큰 갱신
+     */
+    @PatchMapping("/member/refresh")
+    public ResponseEntity<TokenInfo> refreshLogin(@CurrentMember Member member) {
+        return new ResponseEntity<>(memberService.refreshAccessToken(member), HttpStatus.OK);
+    }
 
 }

--- a/src/main/java/com/example/mssaem_backend/domain/member/MemberService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/member/MemberService.java
@@ -172,4 +172,11 @@ public class MemberService {
                 .worryBoardHistory(worryBoardService.getWorryBoardHistory(member))
                 .build();
     }
+
+    public TokenInfo refreshAccessToken(Member member) {
+        return TokenInfo.builder()
+                .accessToken(jwtTokenProvider.generateAccessToken(member.getId()))
+                .refreshToken(member.getRefreshToken())
+                .build();
+    }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/member/MemberService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/member/MemberService.java
@@ -84,7 +84,7 @@ public class MemberService {
         switch (socialLoginType) {
             case KAKAO -> email = socialLoginService.getKaKaoEmail(socialLoginService.getKaKaoAccessToken(idToken));
             case GOOGLE -> email = socialLoginService.getGoogleEmail(socialLoginService.getGoogleAccessToken(idToken));
-            //case NAVER -> email =
+            case NAVER -> email = socialLoginService.getNaverEmail(socialLoginService.getNaverAccessToken(idToken));
         }
 
         Member member = memberRepository.findByEmail(email).orElse(null);

--- a/src/main/java/com/example/mssaem_backend/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/member/dto/MemberResponseDto.java
@@ -17,6 +17,7 @@ import java.util.List;
 public class MemberResponseDto {
 
     @Getter
+    @Builder
     @AllArgsConstructor
     public static class TokenInfo {
 

--- a/src/main/java/com/example/mssaem_backend/global/config/security/oauth/SocialLoginService.java
+++ b/src/main/java/com/example/mssaem_backend/global/config/security/oauth/SocialLoginService.java
@@ -10,11 +10,17 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.URL;
+import java.util.Map;
 import javax.net.ssl.HttpsURLConnection;
 import lombok.extern.slf4j.Slf4j;
+import org.json.simple.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.HttpHandler;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Service
 @Slf4j
@@ -34,6 +40,13 @@ public class SocialLoginService {
     @Value("${social.google.redirect-uri}")
     private String googleRedirectUrl;
 
+    @Value("${social.naver.client-id}")
+    private String naverClientId;
+    @Value("${social.naver.redirect-uri}")
+    private String naverRedirectUrl;
+    @Value("${social.naver.client-secret}")
+    private String naverClientSecret;
+
     public String getGoogleAccessToken(String idToken) throws IOException {
         String reqUrl = "https://oauth2.googleapis.com/token";
         String parameter = "grant_type=" + grantType +
@@ -52,6 +65,52 @@ public class SocialLoginService {
                 "&code=" + idToken;
         return getAccessToken(idToken, reqUrl, parameter);
     }
+
+    public String getNaverAccessToken(String idToken) throws IOException {
+        WebClient webClient = WebClient.builder()
+                .baseUrl("https://nid.naver.com")
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+
+        JSONObject response = webClient.post()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/oauth2.0/token")
+                        .queryParam("client_id", naverClientId)
+                        .queryParam("client_secret", naverClientSecret)
+                        .queryParam("grant_type", grantType)
+                        .queryParam("state", "test")
+                        .queryParam("code", idToken)
+                        .build())
+                .retrieve().bodyToMono(JSONObject.class).block();
+
+        if (response == null) {
+            throw new BaseException(AuthErrorCode.INVALID_ID_TOKEN);
+        }
+
+        return (String) response.get("access_token");
+    }
+
+    public String getNaverEmail(String accessToken) {
+        WebClient webClient = WebClient.builder()
+                .baseUrl("https://openapi.naver.com")
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+
+        JSONObject response = webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/v1/nid/me")
+                        .build())
+                .header("Authorization", "Bearer" + accessToken)
+                .retrieve().bodyToMono(JSONObject.class).block();
+
+        if (response == null) {
+            throw new BaseException(AuthErrorCode.INVALID_ACCESS_TOKEN);
+        }
+
+        Map<String, Object> res = (Map<String, Object>) response.get("response");
+        return (String) res.get("email");
+    }
+
 
     public String getAccessToken(String idToken, String requestUrl, String parameter) throws IOException {
         String accessToken = "";
@@ -97,7 +156,7 @@ public class SocialLoginService {
     }
 
     public String getGoogleEmail(String accessToken) throws IOException {
-        String requestUrl = "https://www.googleapis.com/drive/v2/files";
+        String requestUrl = "https://oauth2.googleapis.com/token";
         StringBuilder result = getEmail(accessToken, requestUrl);
         return new JsonParser().parse(result.toString()).getAsJsonObject().get("email").getAsString();
     }


### PR DESCRIPTION
## 요약

- 리프레시 토큰을 이용한 로그인 토큰 갱신 API
- 네이버 소셜 로그인 API

## 상세 내용

- 리프레시 토큰을 이용한 로그인 토큰 갱신 로직: 클라이언트에서 accessToken을 이용해 로그인 시도 → 이때 클라이언트가 accessToken이 유효하지 않다는 응답을 받을 경우, 이 API 호출 (클라이언트가 헤더에 refreshToken 담아 전송) → refreshToken 의 유효기간을 확인한 후 유효하다면 새로운 accessToken 발급
- 자세한 로직이 궁금하신 분은 `global > config > security > jwt > JwtAuthenticationFilter` 를 봐보시는 걸 추천드립니다..
- 네이버 소셜 로그인 로직: 클라이언트 측에서 네이버 로그인 창 띄우기 → 네이버 측에서 주는 인가 code를 받아 서버로 전달 → 서버는 인가 code를 네이버에게 주고, accessToken을 받아옴 → 다시 한번 accessToken을 네이버에게 주고 유저 정보(email)를 받아옴

## 질문 및 이외 사항

- 카카오와 구글 로그인에서는 Http 요청과 응답을 주고 받을 때 `HttpsURLConnection`을 이용했었는데, 이게 요즘 잘 안 쓰이는 방법이라고 해서 네이버 로그인에 `WebClient`를 사용해보았습니다! 네이버 테스트가 성공하면 카카오와 구글도 `WebClient`를 사용하는 쪽으로 바꿔보겠습니다~
- 소셜 로그인 테스트 해보고 싶으신 분들은 구글 아이디랑 네이버 아이디 남겨주시면 관리자에 추가해드릴게요! 서비스가 배포 전 테스트 단계일 때는 등록되어 있는 아이디로만 테스트가 가능해서요!

## 이슈 번호

- close #15
