### PR TITLE
알림 관련 API 

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentService.java
@@ -10,6 +10,8 @@ import com.example.mssaem_backend.domain.boardcomment.dto.BoardCommentResponseDt
 import com.example.mssaem_backend.domain.boardcommentlike.BoardCommentLikeRepository;
 import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.domain.member.dto.MemberResponseDto.MemberSimpleInfo;
+import com.example.mssaem_backend.domain.notification.NotificationService;
+import com.example.mssaem_backend.domain.notification.TypeEnum;
 import com.example.mssaem_backend.global.common.dto.PageResponseDto;
 import com.example.mssaem_backend.global.config.exception.BaseException;
 import com.example.mssaem_backend.global.config.exception.errorCode.BoardErrorCode;
@@ -31,6 +33,7 @@ public class BoardCommentService {
     private final BoardCommentRepository boardCommentRepository;
     private final BoardCommentLikeRepository boardCommentLikeRepository;
     private final BoardRepository boardRepository;
+    private final NotificationService notificationService;
 
     public List<BoardCommentSimpleInfo> setBoardCommentSimpleInfo(List<BoardComment> boardComments,
         Member viewer) {
@@ -87,12 +90,38 @@ public class BoardCommentService {
 
         //만약 코멘트가 존재한다면 그 댓글에 대댓글
         if (boardCommentRepository.existsBoardCommentById(commentId)) {
-            boardCommentRepository.save(
-                new BoardComment(postBoardCommentReq.getContent(), member, board,
+            BoardComment newBoardComment = boardCommentRepository.save(
+                new BoardComment(
+                    postBoardCommentReq.getContent(),
+                    member,
+                    board,
                     commentId.intValue()));
+            // 글을 쓴 멤버가 아닌 멤버가 댓글을 달 때만 알림 등록
+            if (!board.getId().equals(member.getId())) {
+                notificationService.createNotification(
+                    newBoardComment.getId(),
+                    postBoardCommentReq.getContent(),
+                    TypeEnum.REPLY_OF_COMMENT,
+                    board.getMember()
+                );
+            }
         } else { //존재하지 않다면 새로운 댓글
-            boardCommentRepository.save(
-                new BoardComment(postBoardCommentReq.getContent(), member, board, 0));
+            BoardComment newBoardComment = boardCommentRepository.save(
+                new BoardComment(
+                    postBoardCommentReq.getContent(),
+                    member,
+                    board,
+                    0)
+            );
+            // 글을 쓴 멤버가 아닌 멤버가 댓글을 달 때만 알림 등록
+            if (!board.getId().equals(member.getId())) {
+                notificationService.createNotification(
+                    newBoardComment.getId(),
+                    postBoardCommentReq.getContent(),
+                    TypeEnum.BOARD_COMMENT,
+                    board.getMember()
+                );
+            }
         }
         return true;
     }
@@ -111,7 +140,7 @@ public class BoardCommentService {
         }
         return boardComment.isState();
     }
-  
+
     // 좋아요 수 10개 이상으로 베스트 댓글 3개 조회
     public List<BoardCommentSimpleInfo> findBoardCommentBestListByBoardId(Member viewer,
         Long boardId) {
@@ -122,5 +151,5 @@ public class BoardCommentService {
 
         return setBoardCommentSimpleInfo(boardCommentList, viewer);
     }
-      
+
 }

--- a/src/main/java/com/example/mssaem_backend/domain/chatparticipate/ChatParticipateRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/chatparticipate/ChatParticipateRepository.java
@@ -1,5 +1,6 @@
 package com.example.mssaem_backend.domain.chatparticipate;
 
+import com.example.mssaem_backend.domain.chatroom.ChatRoom;
 import com.example.mssaem_backend.domain.member.Member;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,8 +9,10 @@ import org.springframework.data.repository.query.Param;
 
 public interface ChatParticipateRepository extends JpaRepository<ChatParticipate, Long> {
 
-  @Query("select cp from ChatParticipate cp join fetch cp.chatRoom join fetch cp.member where cp.member = :member")
-  List<ChatParticipate> findAllByMember(@Param("member") Member member);
+    @Query("select cp from ChatParticipate cp join fetch cp.chatRoom join fetch cp.member where cp.member = :member")
+    List<ChatParticipate> findAllByMember(@Param("member") Member member);
 
-  ChatParticipate findBySessionId(String sessionId);
+    ChatParticipate findBySessionId(String sessionId);
+
+    ChatParticipate findByChatRoom(ChatRoom chatRoom);
 }

--- a/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionService.java
@@ -19,6 +19,8 @@ import com.example.mssaem_backend.domain.discussionoptionselected.DiscussionOpti
 import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.domain.member.MemberRepository;
 import com.example.mssaem_backend.domain.member.dto.MemberResponseDto.MemberSimpleInfo;
+import com.example.mssaem_backend.domain.notification.NotificationService;
+import com.example.mssaem_backend.domain.notification.TypeEnum;
 import com.example.mssaem_backend.domain.search.dto.SearchRequestDto.SearchReq;
 import com.example.mssaem_backend.global.common.Time;
 import com.example.mssaem_backend.global.common.dto.PageResponseDto;
@@ -47,6 +49,7 @@ public class DiscussionService {
     private final DiscussionOptionSelectedRepository discussionOptionSelectedRepository;
     private final DiscussionCommentRepository discussionCommentRepository;
     private final BadgeRepository badgeRepository;
+    private final NotificationService notificationService;
     private final MemberRepository memberRepository;
 
 
@@ -301,6 +304,15 @@ public class DiscussionService {
 
             //discussion의 count수 증가
             discussion.increaseCount();
+            //discussion의 참여자수가 10명 이상일 경우 HOT 토론이 됨
+            if (discussion.getParticipantCount() == 10) {
+                notificationService.createNotification(
+                    discussionId,
+                    discussion.getTitle(),
+                    TypeEnum.HOT_DISCUSSION,
+                    discussion.getMember()
+                );
+            }
             discussionOptionSelectedRepository.save(discussionOptionSelected);
         }
 

--- a/src/main/java/com/example/mssaem_backend/domain/discussioncomment/DiscussionCommentService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussioncomment/DiscussionCommentService.java
@@ -10,6 +10,8 @@ import com.example.mssaem_backend.domain.discussioncomment.dto.DiscussionComment
 import com.example.mssaem_backend.domain.discussioncommentlike.DiscussionCommentLikeRepository;
 import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.domain.member.dto.MemberResponseDto.MemberSimpleInfo;
+import com.example.mssaem_backend.domain.notification.NotificationService;
+import com.example.mssaem_backend.domain.notification.TypeEnum;
 import com.example.mssaem_backend.global.common.dto.PageResponseDto;
 import com.example.mssaem_backend.global.config.exception.BaseException;
 import com.example.mssaem_backend.global.config.exception.errorCode.DiscussionErrorCode;
@@ -31,8 +33,10 @@ public class DiscussionCommentService {
     private final DiscussionCommentRepository discussionCommentRepository;
     private final DiscussionCommentLikeRepository discussionCommentLikeRepository;
     private final DiscussionRepository discussionRepository;
+    private final NotificationService notificationService;
 
-    public List<DiscussionCommentSimpleInfo> setDiscussionCommentSimpleInfo(List<DiscussionComment> discussionComments,
+    public List<DiscussionCommentSimpleInfo> setDiscussionCommentSimpleInfo(
+        List<DiscussionComment> discussionComments,
         Member viewer) {
         List<DiscussionCommentSimpleInfo> discussionCommentSimpleInfoList = new ArrayList<>();
 
@@ -45,7 +49,8 @@ public class DiscussionCommentService {
                         discussionComment.getMember())) //해당 게시글을 보는 viewer 와 해당 댓글의 작성자와 같은지 확인
                     .isLiked(
                         discussionCommentLikeRepository.existsDiscussionCommentLikeByMemberAndStateIsTrueAndDiscussionCommentId(
-                            discussionComment.getMember(), discussionComment.getId())) //댓글 좋아요 눌렀는지 안눌렀는지 확인
+                            discussionComment.getMember(),
+                            discussionComment.getId())) //댓글 좋아요 눌렀는지 안눌렀는지 확인
                     .memberSimpleInfo(
                         new MemberSimpleInfo(
                             discussionComment.getMember().getId(),
@@ -65,7 +70,8 @@ public class DiscussionCommentService {
         Member viewer, Long DiscussionId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
 
-        Page<DiscussionComment> result = discussionCommentRepository.findAllByDiscussionId(DiscussionId,
+        Page<DiscussionComment> result = discussionCommentRepository.findAllByDiscussionId(
+            DiscussionId,
             pageable);
 
         return new PageResponseDto<>(
@@ -88,12 +94,38 @@ public class DiscussionCommentService {
 
         //만약 코멘트가 존재한다면 그 댓글에 대댓글
         if (discussionCommentRepository.existsDiscussionCommentById(commentId)) {
-            discussionCommentRepository.save(
-                new DiscussionComment(postDiscussionCommentReq.getContent(), member, discussion,
+            DiscussionComment newDiscussionComment = discussionCommentRepository.save(
+                new DiscussionComment(
+                    postDiscussionCommentReq.getContent(),
+                    member,
+                    discussion,
                     commentId.intValue()));
+            // 글을 쓴 멤버가 아닌 멤버가 댓글을 달 때만 알림 등록
+            if (!discussion.getId().equals(member.getId())) {
+                notificationService.createNotification(
+                    newDiscussionComment.getId(),
+                    postDiscussionCommentReq.getContent(),
+                    TypeEnum.REPLY_OF_COMMENT,
+                    discussion.getMember()
+                );
+            }
         } else { //존재하지 않다면 새로운 댓글
-            discussionCommentRepository.save(
-                new DiscussionComment(postDiscussionCommentReq.getContent(), member, discussion, 0));
+            DiscussionComment newDiscussionComment = discussionCommentRepository.save(
+                new DiscussionComment(
+                    postDiscussionCommentReq.getContent(),
+                    member,
+                    discussion,
+                    0)
+            );
+            // 글을 쓴 멤버가 아닌 멤버가 댓글을 달 때만 알림 등록
+            if (!discussion.getId().equals(member.getId())) {
+                notificationService.createNotification(
+                    newDiscussionComment.getId(),
+                    postDiscussionCommentReq.getContent(),
+                    TypeEnum.DISCUSSION_COMMENT,
+                    discussion.getMember()
+                );
+            }
         }
         return true;
     }
@@ -116,7 +148,8 @@ public class DiscussionCommentService {
     }
 
     // 좋아요 수 10개 이상으로 베스트 댓글 3개 조회
-    public List<DiscussionCommentSimpleInfo> findDiscussionCommentBestListByDiscussionId(Member viewer,
+    public List<DiscussionCommentSimpleInfo> findDiscussionCommentBestListByDiscussionId(
+        Member viewer,
         Long discussionId) {
         PageRequest pageRequest = PageRequest.of(0, 3);
 

--- a/src/main/java/com/example/mssaem_backend/domain/notification/Notification.java
+++ b/src/main/java/com/example/mssaem_backend/domain/notification/Notification.java
@@ -1,12 +1,15 @@
 package com.example.mssaem_backend.domain.notification;
 
+import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.global.common.BaseTimeEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -26,14 +29,28 @@ public class Notification extends BaseTimeEntity {
     private Long id;
 
     @NotNull
+    private Long resourceId;
+
+    @NotNull
     private String content;
 
     private boolean state; // true : 읽음, false : 안 읽음
 
     @NotNull
-    private Long resourceId;
-
-    @NotNull
     @Enumerated(EnumType.STRING)
     private TypeEnum type;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member; // 알림을 받을 멤버
+
+    public Notification(Long resourceId, String content, TypeEnum type, Member member) {
+        this.resourceId = resourceId;
+        this.content = content;
+        this.type = type;
+        this.member = member;
+    }
+
+    public void updateState(boolean state) {
+        this.state = state;
+    }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/notification/NotificationController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/notification/NotificationController.java
@@ -1,9 +1,65 @@
 package com.example.mssaem_backend.domain.notification;
 
+import com.example.mssaem_backend.domain.member.Member;
+import com.example.mssaem_backend.domain.notification.dto.NotificationResponseDto.NotificationInfo;
+import com.example.mssaem_backend.global.common.dto.PageResponseDto;
+import com.example.mssaem_backend.global.config.security.auth.CurrentMember;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
 public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    /**
+     * 알림 목록 조회
+     */
+    @GetMapping("/member/notifications")
+    public ResponseEntity<PageResponseDto<List<NotificationInfo>>> findNotifications(
+        @CurrentMember Member member,
+        @RequestParam int page,
+        @RequestParam int size) {
+        return ResponseEntity.ok(notificationService.findNotifications(member, page, size));
+    }
+
+    /**
+     * 알림 읽기
+     */
+    @PatchMapping("/member/notifications")
+    public ResponseEntity<String> checkNotification(@RequestParam Long id) {
+        return ResponseEntity.ok(notificationService.checkNotification(id));
+    }
+
+    /**
+     * 알림 전체 읽기
+     */
+    @PatchMapping("/member/notifications/all")
+    public ResponseEntity<String> checkAllNotifications(@CurrentMember Member member) {
+        return ResponseEntity.ok(notificationService.checkAllNotifications(member));
+    }
+
+    /**
+     * 알림 삭제하기 (읽은 알림만 가능)
+     */
+    @DeleteMapping("/member/notifications")
+    public ResponseEntity<String> deleteNotification(@RequestParam Long id) {
+        return ResponseEntity.ok(notificationService.deleteNotification(id));
+    }
+
+    /**
+     * 알림 전체 삭제하기
+     */
+    @DeleteMapping("/member/notifications/all")
+    public ResponseEntity<String> deleteAllNotification(@CurrentMember Member member) {
+        return ResponseEntity.ok(notificationService.deleteAllNotifications(member));
+    }
+
 }

--- a/src/main/java/com/example/mssaem_backend/domain/notification/NotificationRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/notification/NotificationRepository.java
@@ -1,6 +1,20 @@
 package com.example.mssaem_backend.domain.notification;
 
+import com.example.mssaem_backend.domain.member.Member;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    Page<Notification> findByMember(Member member, PageRequest pageRequest);
+
+    List<Notification> findByMember(Member member);
+
+    List<Notification> findByMemberAndStateIsFalse(Member member);
+
+    Optional<Notification> findByIdAndStateIsTrue(Long id);
+
 }

--- a/src/main/java/com/example/mssaem_backend/domain/notification/NotificationService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/notification/NotificationService.java
@@ -1,9 +1,124 @@
 package com.example.mssaem_backend.domain.notification;
 
+import static com.example.mssaem_backend.global.common.Time.calculateTime;
+
+import com.example.mssaem_backend.domain.member.Member;
+import com.example.mssaem_backend.domain.notification.dto.NotificationResponseDto.NotificationInfo;
+import com.example.mssaem_backend.global.common.dto.PageResponseDto;
+import com.example.mssaem_backend.global.config.exception.BaseException;
+import com.example.mssaem_backend.global.config.exception.errorCode.NotificationErrorCode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
 public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    // 알림 등록 (게시글 댓글, 토론 댓글, hot 게시글, hot 토론, 대댓글)
+    @Transactional
+    public void createNotification(Long resourceId, String previewContent,
+        TypeEnum type, Member receiver) {
+        previewContent =
+            previewContent.length() >= 20 ? previewContent.substring(0, 20) : previewContent;
+        notificationRepository.save(
+            new Notification(resourceId,
+                type.getName() + "\n\"" + previewContent + "\"",
+                type,
+                receiver
+            )
+        );
+    }
+
+    // 채팅 시작시 알림 등록
+    @Transactional
+    public void createChatNotification(Long resourceId, String previewContent, TypeEnum type,
+        Member sender, Member receiver) {
+        previewContent =
+            previewContent.length() >= 20 ? previewContent.substring(0, 20) : previewContent;
+        notificationRepository.save(
+            new Notification(
+                resourceId,
+                "\"" + sender.getNickName() + "\"님이 " + type.getName() + "\n\"" + previewContent
+                    + "\"",
+                type,
+                receiver)
+        );
+    }
+
+    // 알림 조회
+    public PageResponseDto<List<NotificationInfo>> findNotifications(Member member, int page,
+        int size) {
+        PageRequest pageRequest = PageRequest.of(page, size);
+        Page<Notification> notifications = notificationRepository.findByMember(member, pageRequest);
+
+        return new PageResponseDto<>(
+            notifications.getNumber(),
+            notifications.getTotalPages(),
+            setNotificationInfo(
+                notifications
+                    .stream()
+                    .collect(Collectors.toList()))
+        );
+    }
+
+    // 알림 읽음 처리
+    @Transactional
+    public String checkNotification(Long id) {
+        notificationRepository.findById(id)
+            .orElseThrow(() -> new BaseException(NotificationErrorCode.EMPTY_NOTIFICATION))
+            .updateState(true);
+        return "알림 읽기 완료";
+    }
+
+    // 알림 전체 읽기
+    @Transactional
+    public String checkAllNotifications(Member member) {
+        for (Notification notification : notificationRepository.findByMemberAndStateIsFalse(
+            member)) {
+            notification.updateState(true);
+        }
+        return "알림 전체 읽기 완료";
+    }
+
+    // 알림 삭제하기 (읽은 알림만 가능)
+    @Transactional
+    public String deleteNotification(Long id) {
+        notificationRepository.delete(notificationRepository.findByIdAndStateIsTrue(id)
+            .orElseThrow(() -> new BaseException(NotificationErrorCode.EMPTY_NOTIFICATION)));
+        return "삭제 완료";
+    }
+
+    // 알림 전체 삭제하기
+    @Transactional
+    public String deleteAllNotifications(Member member) {
+        notificationRepository.deleteAll(notificationRepository.findByMember(member));
+        return "알림 전체 삭제 완료";
+    }
+
+
+    // 알림 조회시 Dto 매핑하는 메소드
+    private List<NotificationInfo> setNotificationInfo(List<Notification> notifications) {
+        List<NotificationInfo> notificationInfos = new ArrayList<>();
+
+        for (Notification notification : notifications) {
+            notificationInfos.add(
+                new NotificationInfo(
+                    notification.getId(),
+                    notification.getContent(),
+                    calculateTime(notification.getCreatedAt(), 4),
+                    notification.isState()
+                )
+            );
+        }
+        return notificationInfos;
+    }
+
 }

--- a/src/main/java/com/example/mssaem_backend/domain/notification/TypeEnum.java
+++ b/src/main/java/com/example/mssaem_backend/domain/notification/TypeEnum.java
@@ -1,5 +1,20 @@
 package com.example.mssaem_backend.domain.notification;
 
+import lombok.Getter;
+
 public enum TypeEnum {
-    BOARD, DISCUSSION, WORRYBOARD, CHAT
+    BOARD_COMMENT("내 게시물에 댓글이 달렸어요."),
+    HOT_BOARD("내 게시글이 HOT한 게시글이 되었어요."),
+    DISCUSSION_COMMENT("내 토론에 댓글이 달렸어요."),
+    HOT_DISCUSSION("내 토론이 HOT한 토론이 되었어요."),
+    REPLY_OF_COMMENT("내 댓글에 대댓글이 달렸어요."),
+    HOT_TEACHER("내가 인기 M쌤이 되었어요."),
+    CHAT("채팅을 시작했어요.");
+
+    @Getter
+    private final String name;
+
+    TypeEnum(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/notification/dto/NotificationResponseDto.java
@@ -1,0 +1,21 @@
+package com.example.mssaem_backend.domain.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class NotificationResponseDto {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class NotificationInfo {
+
+        private Long resourceId; // 알림 대상 id
+        private String content; // 알림 내용
+        private String createdAt; // 오늘 알림 : 오전/오후 시간, 오늘 이전 알림 : 0월 0일
+        private boolean state; // true : 읽음, false : 안 읽음
+
+    }
+
+}

--- a/src/main/java/com/example/mssaem_backend/global/common/Time.java
+++ b/src/main/java/com/example/mssaem_backend/global/common/Time.java
@@ -15,13 +15,19 @@ public class Time {
             return dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
         } else if (displayTimeWay == 2) { //날짜와 시간 표시 (게시판 상세 조회, 고민글 상세 조회)
             return dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
-        } else { //실시간 반영 시간 표시 (게시판 전체 조회, 고민 전체 조회, 댓글 전체 조회)
+        } else if (displayTimeWay == 3) { //실시간 반영 시간 표시 (게시판 전체 조회, 고민 전체 조회, 댓글 전체 조회)
             if (minutes < 60) {
                 return minutes + "분 전";
             } else if (hours < 24) {
                 return hours + "시간 전";
             } else {
                 return dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+            }
+        } else { // 알림 시간 표시
+            if (hours < 24) { // 오늘이면
+                return dateTime.format(DateTimeFormatter.ofPattern("a hh:mm"));
+            } else { // 오늘이 아니면
+                return dateTime.format(DateTimeFormatter.ofPattern("MM월 dd일"));
             }
         }
     }

--- a/src/main/java/com/example/mssaem_backend/global/config/exception/errorCode/NotificationErrorCode.java
+++ b/src/main/java/com/example/mssaem_backend/global/config/exception/errorCode/NotificationErrorCode.java
@@ -1,0 +1,16 @@
+package com.example.mssaem_backend.global.config.exception.errorCode;
+
+import com.example.mssaem_backend.global.config.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationErrorCode implements ErrorCode {
+    EMPTY_NOTIFICATION("NOTIFICATION_001", "존재하지 않는 알림입니다.", HttpStatus.NOT_FOUND);
+
+    private final String errorCode;
+    private final String message;
+    private final HttpStatus status;
+}


### PR DESCRIPTION
## 요약

- 알림 등록, 알림 조회 
    - 내 게시글에 댓글 달릴 때
    - 내 토론에 댓글 달릴 때
    - 내 댓글에 대댓글 달릴 때
    - M쌤 매칭됐을 때
    - 핫게, 핫토론이 됐을 때
-  알림 읽기, 전체 알림 읽기
- 알림 삭제하기 (읽은 알림만), 전체 알림 삭제하기 (읽든 안읽든 모든 알림 삭제)

## 상세 내용
### TypeEnum
- 각 enum의 name 값에 고정 알림 메시지로 보내줄 내용을 저장
### Time
- 알림 메시지의 경우 오늘일 때는 "오전/오후 00:00"으로 표시하고 오늘이 아닐 때는 "00월 00일"로 표시하는 로직 추가 
### NotificationController
- 알림 목록 조회 API
- 알림 읽기 API
- 알림 전체 읽기 API
- 알림 삭제하기 (읽은 알림만 가능)
- 알림 전체 삭제하기
### NotificationService
- `createNotification` : 채팅 이외의 알림 type에 대해 내용을 테이블에 저장하는 메소드 
- `createChatNotification` : 채팅이 시작되었을 때 알림 내용을 테이블에 저장하는 메소드
​    - 채팅의 경우 채팅을 시작한 사람의 닉네임이 들어가야해서 메소드를 따로 만듦
- `findNotifications` : 알림 조회 메소드 
- `checkNotification` : id에 해당하는 알림만 읽음 처리해주는 메소드
- `checkAllNotifications` : 로그인한 유저의 모든 알림을 읽음 처리해주는 메소드
- `deleteNotification` : id에 해당하는 알림만 삭제해주는 메소드
- `deleteAllNotifications` : 읽음 여부와 상관없이 로그인한 유저의 모든 알림을 삭제해주는 메소드
- `setNotificationInfo` : 알림 조회시 Dto 매핑하는 메소드
### BoardCommentService, DiscussionCommentService
- 댓글과 대댓글이 달릴 때 알림 등록
    - 댓글을 다는 유저가 게시물과 토론을 쓴 유저가 아닐 경우에만 알림 등록
### LikeService
- 좋아요가 달리는 게시물의 좋아요 수가 10개(HOT 게시물 기준)가 될때만 알림 등록
### DiscussionService
- 토론 참여자수가 10개(HOT 토론의 기준)가 될때만 알림 등록
### ChatParticipateService
``` java
        // 채팅방이 만들어져 있고 해당 채팅방의 두번째 참가자(고민을 올린 사람)일 경우 채팅 시작 알림 전송
        ChatParticipate prevParticipate = chatParticipateRepository.findByChatRoom(chatRoom);
        System.out.println(prevParticipate +"존재함");
        if (prevParticipate != null) {
            notificationService.createChatNotification(
                chatRoom.getId(),
                chatRoom.getTitle(),
                TypeEnum.CHAT,
                prevParticipate.getMember(),
                member
            );
        }
```
## 질문 및 이외 사항

❗️다른 분들이 만들어둔 코드가 많이 수정되었습니다..! postman을 이용한 테스트는 문제없이 잘 수행됐지만 혹시 모르니 각자 맡은 파트의 Service 클래스를 꼭 읽어봐주세요! 

## 이슈 번호

- #135
