### PR TITLE
고민글 파일 업로드 API 분리

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoard.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoard.java
@@ -64,11 +64,12 @@ public class WorryBoard extends BaseTimeEntity {
 
     @Builder
     public WorryBoard(String title, String content, MbtiEnum targetMbti,
-        Member member) {
+        Member member, String thumbnail) {
         this.title = title;
         this.content = content;
         this.targetMbti = targetMbti;
         this.member = member;
+        this.thumbnail = thumbnail;
     }
 
     public void solveWorryBoard(Member solveMember) {
@@ -93,5 +94,9 @@ public class WorryBoard extends BaseTimeEntity {
 
     public void updateState() {
         this.state = false;
+    }
+
+    public void changeThumbnail(String thumbnail) {
+        this.thumbnail = thumbnail;
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardController.java
@@ -22,7 +22,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @RestController

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardController.java
@@ -103,9 +103,9 @@ public class WorryBoardController {
     @PostMapping("/member/worry-board")
     public ResponseEntity<String> createWorryBoard(@CurrentMember Member currentMember,
         @RequestPart(value = "postWorryReq") PostWorryReq postWorryReq,
-        @RequestPart(value = "image", required = false) List<MultipartFile> multipartFiles) {
+        @RequestPart(value = "image", required = false) List<String> imgUrls) {
         return ResponseEntity.ok(
-            worryBoardService.createWorryBoard(currentMember, postWorryReq, multipartFiles));
+            worryBoardService.createWorryBoard(currentMember, postWorryReq, imgUrls));
     }
 
     //고민글 수정
@@ -113,9 +113,9 @@ public class WorryBoardController {
     public ResponseEntity<String> modifyWorryBoard(@CurrentMember Member currentMember,
         @PathVariable Long id,
         @RequestPart(value = "patchWorryReq") PatchWorryReq patchWorryReq,
-        @RequestPart(value = "image", required = false) List<MultipartFile> multipartFiles) {
+        @RequestPart(value = "image", required = false) List<String> imgUrls) {
         return ResponseEntity.ok(
-            worryBoardService.modifyWorryBoard(currentMember, id, patchWorryReq, multipartFiles));
+            worryBoardService.modifyWorryBoard(currentMember, id, patchWorryReq, imgUrls));
     }
 
     //고민글 삭제

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
@@ -47,25 +47,25 @@ public class WorryBoardService {
     //List<WorryBoard>를 받아서 List<GetWorriesRes> 리스트를 반환하는 함수
     private List<GetWorriesRes> makeGetWorriesResForm(Page<WorryBoard> result) {
         return result.stream().map(worryBoard -> GetWorriesRes.builder().worryBoard(worryBoard)
-                .imgUrl(worryBoardImageService.getImgUrl(worryBoard))
-                .createdAt(calculateTime(worryBoard.getCreatedAt(), 3))
-                .build()).toList();
+            .imgUrl(worryBoardImageService.getImgUrl(worryBoard))
+            .createdAt(calculateTime(worryBoard.getCreatedAt(), 3))
+            .build()).toList();
     }
 
     //고민게시판 - 고민 목록 조회
     public PageResponseDto<List<GetWorriesRes>> findWorriesBySolved(boolean isSolved, int page,
-                                                                    int size) {
+        int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<WorryBoard> result = worryBoardRepository.findByIsSolvedAndStateTrueOrderByCreatedAtDesc(
-                isSolved, pageable);
+            isSolved, pageable);
         return new PageResponseDto<>(result.getNumber(), result.getTotalPages(),
-                makeGetWorriesResForm(result));
+            makeGetWorriesResForm(result));
     }
 
     //고민 게시판 - 고민글 상세 조회
     public GetWorryRes findWorryById(Member viewer, Long id) {
         WorryBoard worryBoard = worryBoardRepository.findById(id)
-                .orElseThrow(() -> new BaseException(WorryBoardErrorCode.EMPTY_WORRY_BOARD));
+            .orElseThrow(() -> new BaseException(WorryBoardErrorCode.EMPTY_WORRY_BOARD));
         Member member = worryBoard.getMember();
 
         //수정,삭제 권한 확인
@@ -73,48 +73,48 @@ public class WorryBoardService {
 
         //채팅 시작 권한 확인
         Boolean isChatAllowed = (viewer != null && viewer.getMbti()
-                .equals(worryBoard.getTargetMbti()));
+            .equals(worryBoard.getTargetMbti()));
 
         return GetWorryRes.builder()
-                .worryBoard(worryBoard)
-                .imgList(worryBoardImageService.getImgUrls(worryBoard))
-                .createdAt(calculateTime(worryBoard.getCreatedAt(), 2))
-                .memberSimpleInfo(
-                        new MemberSimpleInfo(member.getId(), member.getNickName(), member.getDetailMbti(),
-                                badgeService.findRepresentativeBadgeByMember(member),
-                                member.getProfileImageUrl()))
-                .isEditAllowed(isEditAllowed)
-                .isChatAllowed(isChatAllowed)
-                .build();
+            .worryBoard(worryBoard)
+            .imgList(worryBoardImageService.getImgUrls(worryBoard))
+            .createdAt(calculateTime(worryBoard.getCreatedAt(), 2))
+            .memberSimpleInfo(
+                new MemberSimpleInfo(member.getId(), member.getNickName(), member.getDetailMbti(),
+                    badgeService.findRepresentativeBadgeByMember(member),
+                    member.getProfileImageUrl()))
+            .isEditAllowed(isEditAllowed)
+            .isChatAllowed(isChatAllowed)
+            .build();
     }
 
     //특정 멤버별 올린 고민 목록 조회
     public PageResponseDto<List<GetWorriesRes>> findWorriesByMemberId(Long memberId, int page,
-                                                                      int size) {
+        int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<WorryBoard> result = worryBoardRepository.findByMemberIdAndStateTrueOrderByCreatedAtDesc(
-                memberId,
-                pageable);
+            memberId,
+            pageable);
         return new PageResponseDto<>(result.getNumber(), result.getTotalPages(),
-                makeGetWorriesResForm(result));
+            makeGetWorriesResForm(result));
     }
 
     //특정 멤버별 해결한 고민 목록 조회
     public PageResponseDto<List<GetWorriesRes>> findSolveWorriesByMemberId(Long memberId, int page,
-                                                                           int size) {
+        int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<WorryBoard> result = worryBoardRepository.findBySolveMemberIdAndStateTrueOrderByCreatedAtDesc(
-                memberId,
-                pageable);
+            memberId,
+            pageable);
         return new PageResponseDto<>(result.getNumber(), result.getTotalPages(),
-                makeGetWorriesResForm(result));
+            makeGetWorriesResForm(result));
     }
 
     // mbti 필터링 조회
     public PageResponseDto<List<GetWorriesRes>> findWorriesByMbti(Boolean isSolved,
-                                                                  String strFromMbti,
-                                                                  String strToMbti,
-                                                                  int page, int size) {
+        String strFromMbti,
+        String strToMbti,
+        int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
 
         boolean isFromAll = strFromMbti.equals("ALL");
@@ -125,10 +125,10 @@ public class WorryBoardService {
         MbtiEnum toMbti = isToAll ? null : MbtiEnum.valueOf(strToMbti);
 
         Page<WorryBoard> result = worryBoardRepository.findWorriesBySolvedAndBothMbtiAndStateTrue(
-                isSolved, fromMbti, toMbti, pageable);
+            isSolved, fromMbti, toMbti, pageable);
 
         return new PageResponseDto<>(result.getNumber(), result.getTotalPages(),
-                makeGetWorriesResForm(result));
+            makeGetWorriesResForm(result));
     }
 
     // 홈 화면에 보여줄 해결안된 고민글 최신순으로 조회
@@ -139,80 +139,82 @@ public class WorryBoardService {
         }
 
         return worryBoards.stream()
-                .map(worryBoard -> GetWorriesRes.builder()
-                        .worryBoard(worryBoard)
-                        .imgUrl(worryBoardImageService.getImgUrl(worryBoard))
-                        .createdAt(calculateTime(worryBoard.getCreatedAt(), 2))
-                        .build())
-                .toList();
+            .map(worryBoard -> GetWorriesRes.builder()
+                .worryBoard(worryBoard)
+                .imgUrl(worryBoardImageService.getImgUrl(worryBoard))
+                .createdAt(calculateTime(worryBoard.getCreatedAt(), 2))
+                .build())
+            .toList();
     }
 
     @Transactional
     // 고민 해결 완료
     public PatchWorrySolvedRes solveWorryBoard(Member currentMember, Long id,
-                                               PatchWorrySolvedReq patchWorryReq) {
+        PatchWorrySolvedReq patchWorryReq) {
         WorryBoard worryBoard = worryBoardRepository.findById(id)
-                .orElseThrow(() -> new BaseException(WorryBoardErrorCode.EMPTY_WORRY_BOARD));
+            .orElseThrow(() -> new BaseException(WorryBoardErrorCode.EMPTY_WORRY_BOARD));
         match(currentMember, worryBoard.getMember());
 
         Member solveMember = memberRepository.findById(patchWorryReq.getWorrySolverId())
-                .orElseThrow(() -> new BaseException(MemberErrorCode.EMPTY_MEMBER));
+            .orElseThrow(() -> new BaseException(MemberErrorCode.EMPTY_MEMBER));
         // 고민글의 상태 바꾸기
         worryBoard.solveWorryBoard(solveMember);
         // 평가창에 뜰 memberSimpleInfo, worryBoard Id 반환
         return PatchWorrySolvedRes.builder()
-                .memberSimpleInfo(
-                        new MemberSimpleInfo(
-                                solveMember.getId(), solveMember.getNickName(),
-                                solveMember.getDetailMbti(),
-                                badgeService.findRepresentativeBadgeByMember(solveMember),
-                                solveMember.getProfileImageUrl())
-                )
-                .worryBoardId(id).build();
+            .memberSimpleInfo(
+                new MemberSimpleInfo(
+                    solveMember.getId(), solveMember.getNickName(),
+                    solveMember.getDetailMbti(),
+                    badgeService.findRepresentativeBadgeByMember(solveMember),
+                    solveMember.getProfileImageUrl())
+            )
+            .worryBoardId(id).build();
     }
 
     //고민글 생성
+    @Transactional
     public String createWorryBoard(Member currentMember, PostWorryReq postWorryReq,
-                                   List<MultipartFile> multipartFiles) {
+        List<String> imgUrls) {
         //고민글 내용 저장
         WorryBoard worryBoard = WorryBoard.builder()
-                .title(postWorryReq.getTitle())
-                .content(postWorryReq.getContent())
-                .targetMbti(postWorryReq.getTargetMbti())
-                .member(currentMember)
-                .build();
-        worryBoardRepository.save(worryBoard);
+            .title(postWorryReq.getTitle())
+            .content(postWorryReq.getContent())
+            .targetMbti(postWorryReq.getTargetMbti())
+            .member(currentMember)
+            .thumbnail(null)
+            .build();
 
         //S3 처리 worryBoardImageService에 전달
-        if (multipartFiles != null) {
-            worryBoardImageService.saveWorryImage(worryBoard, multipartFiles);
+        if (imgUrls != null) {
+            String thumbnail = worryBoardImageService.uploadWorryBoardImageUrl(worryBoard, imgUrls);
+            worryBoard.changeThumbnail(thumbnail);
         }
+        worryBoardRepository.save(worryBoard);
         return "고민글 생성 완료";
     }
 
     //고민글 수정
     @Transactional
     public String modifyWorryBoard(Member currentMember, Long id, PatchWorryReq patchWorryReq,
-                                   List<MultipartFile> multipartFiles) {
+        List<String> imgUrls) {
         //현재 멤버와 작성자 일치하는 지 확인
         WorryBoard worryBoard = worryBoardRepository.findById(id)
-                .orElseThrow(() -> new BaseException(WorryBoardErrorCode.EMPTY_WORRY_BOARD));
-        if (!currentMember.getId().equals(worryBoard.getMember().getId())) {
-            throw new BaseException(MemberErrorCode.INVALID_MEMBER);
-        }
+            .orElseThrow(() -> new BaseException(WorryBoardErrorCode.EMPTY_WORRY_BOARD));
         match(currentMember, worryBoard.getMember());
 
         //worryBoard 수정하기
         worryBoard.modifyWorryBoard(
-                patchWorryReq.getTitle(),
-                patchWorryReq.getContent(),
-                patchWorryReq.getTargetMbti()
+            patchWorryReq.getTitle(),
+            patchWorryReq.getContent(),
+            patchWorryReq.getTargetMbti()
         );
 
-        //S3 처리 worryBoardImageService로 전달
-        worryBoardImageService.deleteWorryImage(worryBoard);
-        if (multipartFiles != null) {
-            worryBoardImageService.saveWorryImage(worryBoard, multipartFiles);
+        worryBoardImageService.deleteWorryBoardImage(worryBoard);
+        if (imgUrls != null) {
+            worryBoard.changeThumbnail(
+                worryBoardImageService.uploadWorryBoardImageUrl(worryBoard, imgUrls));
+        } else {
+            worryBoard.changeThumbnail(null);
         }
         return "고민글 수정 완료";
     }
@@ -222,18 +224,18 @@ public class WorryBoardService {
     public String deleteWorryBoard(Member currentMember, Long id) {
         //현재 멤버와 작성자 일치하는 지 확인
         WorryBoard worryBoard = worryBoardRepository.findById(id)
-                .orElseThrow(() -> new BaseException(WorryBoardErrorCode.EMPTY_WORRY_BOARD));
+            .orElseThrow(() -> new BaseException(WorryBoardErrorCode.EMPTY_WORRY_BOARD));
         match(currentMember, worryBoard.getMember());
 
         worryBoard.deleteWorryBoard();
-        worryBoardImageService.deleteWorryImage(worryBoard);
+        worryBoardImageService.deleteWorryBoardImage(worryBoard);
 
         return "고민글 삭제 완료";
     }
 
     // 해결된 고민글 중에서 검색하기
     public PageResponseDto<List<GetWorriesRes>> findSolvedWorriesByKeywordAndMbti(
-            SearchReq searchReq, String strFromMbti, String strToMbti, int page, int size) {
+        SearchReq searchReq, String strFromMbti, String strToMbti, int page, int size) {
         PageRequest pageRequest = PageRequest.of(page, size);
 
         // ALL인 경우에 mbti에는 null값이 들어감
@@ -241,15 +243,15 @@ public class WorryBoardService {
         MbtiEnum toMbti = strToMbti.equals("ALL") ? null : MbtiEnum.valueOf(strToMbti);
 
         Page<WorryBoard> worryBoards = worryBoardRepository.searchWorriesBySolvedAndTypeAndMbti(
-                searchReq.getType(), searchReq.getKeyword(), true, fromMbti, toMbti, pageRequest);
+            searchReq.getType(), searchReq.getKeyword(), true, fromMbti, toMbti, pageRequest);
 
         return new PageResponseDto<>(worryBoards.getNumber(), worryBoards.getTotalPages(),
-                makeGetWorriesResForm(worryBoards));
+            makeGetWorriesResForm(worryBoards));
     }
 
     // 해결 안 된 고민글 중에서 검색하기
     public PageResponseDto<List<GetWorriesRes>> findWaitingWorriesByKeywordAndMbti(
-            SearchReq searchReq, String strFromMbti, String strToMbti, int page, int size) {
+        SearchReq searchReq, String strFromMbti, String strToMbti, int page, int size) {
         PageRequest pageRequest = PageRequest.of(page, size);
 
         // ALL인 경우에 mbti에는 null값이 들어감
@@ -257,17 +259,17 @@ public class WorryBoardService {
         MbtiEnum toMbti = strToMbti.equals("ALL") ? null : MbtiEnum.valueOf(strToMbti);
 
         Page<WorryBoard> worryBoards = worryBoardRepository.searchWorriesBySolvedAndTypeAndMbti(
-                searchReq.getType(), searchReq.getKeyword(), false, fromMbti, toMbti, pageRequest);
+            searchReq.getType(), searchReq.getKeyword(), false, fromMbti, toMbti, pageRequest);
 
         return new PageResponseDto<>(worryBoards.getNumber(), worryBoards.getTotalPages(),
-                makeGetWorriesResForm(worryBoards));
+            makeGetWorriesResForm(worryBoards));
     }
 
     public WorryBoardHistory getWorryBoardHistory(Member member) {
         return new WorryBoardHistory(
-                worryBoardRepository.countAllByStateIsTrueAndMember(member),
-                worryBoardRepository.countALlBySolveMember(member),
-                evaluationRepository.countAllByMember(member)
+            worryBoardRepository.countAllByStateIsTrueAndMember(member),
+            worryBoardRepository.countALlBySolveMember(member),
+            evaluationRepository.countAllByMember(member)
         );
     }
 

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
@@ -14,25 +14,22 @@ import com.example.mssaem_backend.domain.search.dto.SearchRequestDto.SearchReq;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.PatchWorryReq;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.PatchWorrySolvedReq;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.PostWorryReq;
-import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardResponseDto.WorryBoardHistory;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardResponseDto.GetWorriesRes;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardResponseDto.GetWorryRes;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardResponseDto.PatchWorrySolvedRes;
+import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardResponseDto.WorryBoardHistory;
 import com.example.mssaem_backend.domain.worryboardimage.WorryBoardImageService;
 import com.example.mssaem_backend.global.common.dto.PageResponseDto;
 import com.example.mssaem_backend.global.config.exception.BaseException;
 import com.example.mssaem_backend.global.config.exception.errorCode.MemberErrorCode;
 import com.example.mssaem_backend.global.config.exception.errorCode.WorryBoardErrorCode;
-
 import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageController.java
@@ -1,7 +1,5 @@
 package com.example.mssaem_backend.domain.worryboardimage;
 
-import com.example.mssaem_backend.domain.member.Member;
-import com.example.mssaem_backend.global.config.security.auth.CurrentMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,8 +14,8 @@ public class WorryBoardImageController {
     private final WorryBoardImageService worryBoardImageService;
 
     @PostMapping("/member/worry-boards/files")
-    public ResponseEntity<String> uploadFiles(@CurrentMember Member member,
-        @RequestPart(value="image", required = false)MultipartFile multipartFile) {
+    public ResponseEntity<String> uploadFiles(
+        @RequestPart(value = "image", required = false) MultipartFile multipartFile) {
         return ResponseEntity.ok(worryBoardImageService.uploadFile(multipartFile));
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageController.java
@@ -1,9 +1,23 @@
 package com.example.mssaem_backend.domain.worryboardimage;
 
+import com.example.mssaem_backend.domain.member.Member;
+import com.example.mssaem_backend.global.config.security.auth.CurrentMember;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @RestController
 public class WorryBoardImageController {
+
+    private final WorryBoardImageService worryBoardImageService;
+
+    @PostMapping("/member/worry-boards/files")
+    public ResponseEntity<String> uploadFiles(@CurrentMember Member member,
+        @RequestPart(value="image", required = false)MultipartFile multipartFile) {
+        return ResponseEntity.ok(worryBoardImageService.uploadFile(multipartFile));
+    }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageService.java
@@ -2,7 +2,6 @@ package com.example.mssaem_backend.domain.worryboardimage;
 
 import com.example.mssaem_backend.domain.worryboard.WorryBoard;
 import com.example.mssaem_backend.global.s3.S3Service;
-import com.example.mssaem_backend.global.s3.dto.S3Result;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboardimage/WorryBoardImageService.java
@@ -3,6 +3,7 @@ package com.example.mssaem_backend.domain.worryboardimage;
 import com.example.mssaem_backend.domain.worryboard.WorryBoard;
 import com.example.mssaem_backend.global.s3.S3Service;
 import com.example.mssaem_backend.global.s3.dto.S3Result;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -39,38 +40,30 @@ public class WorryBoardImageService {
         return worryBoardImage.getImgUrl();
     }
 
-    //이미지 s3 저장 후 worryBoardImage 생성
-    public void saveWorryImage(WorryBoard worryBoard, List<MultipartFile> multipartFiles) {
-        //s3 저장 후 url리스트 가져오기
-        List<S3Result> s3ResultList = s3Service.uploadFile(multipartFiles);
+    //전달받은 imgUrl 리스트 DB에 저장
+    public String uploadWorryBoardImageUrl(WorryBoard worryboard, List<String> imgUrls) {
+        List<WorryBoardImage> worryBoardImages = new ArrayList<>();
 
-        //반환된 url을 worryBoardImage로 저장
-        if (!s3ResultList.isEmpty()) {
-            for (S3Result s3Result : s3ResultList) {
-                worryBoardImageRepository.save(WorryBoardImage.builder()
-                    .worryBoard(worryBoard)
-                    .imgUrl(s3Result.getImgUrl())
-                    .build());
+        if(!imgUrls.isEmpty()) {
+            for(String result : imgUrls) {
+                worryBoardImages.add(new WorryBoardImage(worryboard, result));
             }
         }
+        worryBoardImageRepository.saveAll(worryBoardImages);
+
+        return imgUrls.isEmpty() ? null : imgUrls.get(0);
     }
 
-
-    //s3 이미지 삭제 후 worryBoardImage 삭제
-    public void deleteWorryImage(WorryBoard worryBoard) {
-        List<WorryBoardImage> worryBoardImages = worryBoardImageRepository.findAllByWorryBoard(
-            worryBoard);
-
-        //해당 worryBoard에 존재하는 s3 파일 삭제
-        if (!worryBoardImages.isEmpty()) {
-            for (WorryBoardImage worryBoardImage : worryBoardImages) {
-                s3Service.deleteFile(
-                    s3Service.parseFileName(worryBoardImage.getImgUrl())
-                );
-            }
+    public void deleteWorryBoardImage(WorryBoard worryBoard) {
+        List<WorryBoardImage> worryBoardImages = worryBoardImageRepository.findAllByWorryBoard(worryBoard);
+        //s3 삭제
+        for(WorryBoardImage worryBoardimage : worryBoardImages) {
+            s3Service.deleteFile(s3Service.parseFileName(worryBoardimage.getImgUrl()));
         }
-
-        //해당 worryBoard에 존재하는 worryBoardImage 삭제
         worryBoardImageRepository.deleteAllByWorryBoard(worryBoard);
+    }
+
+    public String uploadFile(MultipartFile multipartFile) {
+        return s3Service.uploadImage(multipartFile);
     }
 }


### PR DESCRIPTION
## 요약

- 프론트 요청에 따른 고민글 생성, 수정 API 변경

## 상세 내용

- 고민글 내용과 이미지를 한번에 받아오는 방식에서 분리했습니다.
- 이전에 리우가 수정한 게시판 이미지 처리와 동일합니다!
1.  에디터에 사진을 하나 늘 때 마다 imgUrl 하나씩 전송
2.  글을 완료하면 글 내용이랑, List를 줌
3.  이것을 DB에 저장

## 질문 및 이외 사항

- 

## 이슈 번호

- closed #141 
