### PR TITLE
게시글 삭제 시 게시글 좋아요 / 댓글 좋아요/ 댓글 모두 삭제

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
@@ -12,6 +12,7 @@ import com.example.mssaem_backend.domain.board.dto.BoardResponseDto.BoardSimpleI
 import com.example.mssaem_backend.domain.board.dto.BoardResponseDto.GetBoardRes;
 import com.example.mssaem_backend.domain.board.dto.BoardResponseDto.ThreeHotInfo;
 import com.example.mssaem_backend.domain.boardcomment.BoardCommentRepository;
+import com.example.mssaem_backend.domain.boardcomment.BoardCommentService;
 import com.example.mssaem_backend.domain.boardimage.BoardImageService;
 import com.example.mssaem_backend.domain.discussion.Discussion;
 import com.example.mssaem_backend.domain.discussion.DiscussionRepository;
@@ -47,6 +48,7 @@ public class BoardService {
     private final BadgeRepository badgeRepository;
     private final DiscussionRepository discussionRepository;
     private final WorryBoardRepository worryBoardRepository;
+    private final BoardCommentService boardCommentService;
 
     // HOT 게시물 더보기
     public PageResponseDto<List<BoardSimpleInfo>> findHotBoardList(int page, int size) {
@@ -170,6 +172,8 @@ public class BoardService {
             boardImageService.deleteBoardImage(board);
             //해당 게시글 좋아요 삭제
             likeRepository.deleteAllByBoard(board);
+            //게시글 삭제 시 모든 댓글 삭제, 댓글 좋아요 삭제
+            boardCommentService.deleteAllBoardComment(board);
             return "게시글 삭제 완료";
         } else {
             throw new BaseException(BoardErrorCode.EMPTY_BOARD);
@@ -207,7 +211,8 @@ public class BoardService {
     //게시글 전체 조회 , 게시글 상세 조회시 boardId 입력 받아 현재 게시글 제외하고 전체 조회
     public PageResponseDto<List<BoardSimpleInfo>> findBoards(int page, int size, Long boardId) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<Board> result = boardRepository.findAllByStateIsTrueAndIdOrderByCreatedAtDesc(boardId, pageable);
+        Page<Board> result = boardRepository.findAllByStateIsTrueAndIdOrderByCreatedAtDesc(boardId,
+            pageable);
         return new PageResponseDto<>(
             result.getNumber(),
             result.getTotalPages(),
@@ -222,7 +227,8 @@ public class BoardService {
     public PageResponseDto<List<BoardSimpleInfo>> findBoardsByMbti(MbtiEnum mbti, int page,
         int size) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<Board> result = boardRepository.findAllByStateIsTrueAndMbtiOrderByCreatedAtDesc(mbti, pageable);
+        Page<Board> result = boardRepository.findAllByStateIsTrueAndMbtiOrderByCreatedAtDesc(mbti,
+            pageable);
         return new PageResponseDto<>(
             result.getNumber(),
             result.getTotalPages(),
@@ -237,7 +243,8 @@ public class BoardService {
     public PageResponseDto<List<BoardSimpleInfo>> findBoardsByMemberId(Long id, int page,
         int size) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<Board> result = boardRepository.findAllByMemberIdAndStateIsTrueOrderByCreatedAtDesc(id, pageable);
+        Page<Board> result = boardRepository.findAllByMemberIdAndStateIsTrueOrderByCreatedAtDesc(id,
+            pageable);
         return new PageResponseDto<>(
             result.getNumber(),
             result.getTotalPages(),
@@ -300,9 +307,9 @@ public class BoardService {
 
     public BoardHistory getBoardHistory(Member member) {
         return new BoardHistory(
-                boardRepository.countAllByStateIsTrueAndMember(member),
-                boardCommentRepository.countAllByStateIsTrueAndMember(member),
-                boardRepository.sumLikeCountByMember(member)
+            boardRepository.countAllByStateIsTrueAndMember(member),
+            boardCommentRepository.countAllByStateIsTrueAndMember(member),
+            boardRepository.sumLikeCountByMember(member)
         );
     }
 

--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
@@ -168,6 +168,8 @@ public class BoardService {
             board.deleteBoard();
             //현재 저장된 이미지 삭제
             boardImageService.deleteBoardImage(board);
+            //해당 게시글 좋아요 삭제
+            likeRepository.deleteAllByBoard(board);
             return "게시글 삭제 완료";
         } else {
             throw new BaseException(BoardErrorCode.EMPTY_BOARD);

--- a/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentRepository.java
@@ -29,4 +29,6 @@ public interface BoardCommentRepository extends JpaRepository<BoardComment, Long
 
     Page<BoardComment> findAllByMemberIdAndStateIsTrue(Long memberId, Pageable pageable);
 
+    List<BoardComment> deleteAllByBoard(Board board);
+
 }

--- a/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentService.java
@@ -7,8 +7,8 @@ import com.example.mssaem_backend.domain.board.Board;
 import com.example.mssaem_backend.domain.board.BoardRepository;
 import com.example.mssaem_backend.domain.boardcomment.dto.BoardCommentRequestDto.PostBoardCommentReq;
 import com.example.mssaem_backend.domain.boardcomment.dto.BoardCommentResponseDto.BoardCommentSimpleInfo;
-import com.example.mssaem_backend.domain.boardcomment.dto.BoardCommentResponseDto.PostBoardCommentRes;
 import com.example.mssaem_backend.domain.boardcomment.dto.BoardCommentResponseDto.BoardCommentSimpleInfoByMember;
+import com.example.mssaem_backend.domain.boardcomment.dto.BoardCommentResponseDto.PostBoardCommentRes;
 import com.example.mssaem_backend.domain.boardcommentlike.BoardCommentLikeRepository;
 import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.domain.member.dto.MemberResponseDto.MemberSimpleInfo;
@@ -204,6 +204,19 @@ public class BoardCommentService {
                     .stream()
                     .collect(Collectors.toList()), viewer)
         );
+    }
+
+    //게시글 삭제 시 해당 게시글 댓글 완전 삭제
+    @Transactional
+    public Boolean deleteAllBoardComment(Board board) {
+        List<BoardComment> comments = boardCommentRepository.findAllByBoardId(board.getId());
+        //모든 댓글에 대한 댓글 좋아요 먼저 삭제
+        for (BoardComment comment : comments) {
+            boardCommentLikeRepository.deleteAllByBoardComment(comment);
+        }
+        // 게시글에 대한 모든 댓글 삭제
+        boardCommentRepository.deleteAllByBoard(board);
+        return true;
     }
 
 }

--- a/src/main/java/com/example/mssaem_backend/domain/boardcommentlike/BoardCommentLikeRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardcommentlike/BoardCommentLikeRepository.java
@@ -2,6 +2,7 @@ package com.example.mssaem_backend.domain.boardcommentlike;
 
 import com.example.mssaem_backend.domain.boardcomment.BoardComment;
 import com.example.mssaem_backend.domain.member.Member;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -23,4 +24,6 @@ public interface BoardCommentLikeRepository extends JpaRepository<BoardCommentLi
         Long boardCommentId);
 
     Boolean existsBoardCommentLikeByMemberAndBoardCommentId(Member member, Long bardCommentId);
+
+    List<BoardCommentLike> deleteAllByBoardComment(BoardComment boardComment);
 }

--- a/src/main/java/com/example/mssaem_backend/domain/like/LikeRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/like/LikeRepository.java
@@ -3,6 +3,7 @@ package com.example.mssaem_backend.domain.like;
 import com.example.mssaem_backend.domain.board.Board;
 import com.example.mssaem_backend.domain.member.Member;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -24,4 +25,6 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
 
     @Query(value = "SELECT COUNT(l) FROM Like l WHERE l.board.member = :member AND l.board.state = true AND l.state = true")
     Integer countLikesByMember(@Param("member") Member member);
+
+    List<Like> deleteAllByBoard(Board board);
 }


### PR DESCRIPTION
## 요약

- 게시글 삭제 시 이미지만 지우는 것에 이어 추가로 게시글 좋아요 / 댓글 좋아요/ 댓글 을 삭제 합니다.

## 상세 내용

### BoardService
- `deleteBoard()` : 기존의 이미지만 삭제하던 방식에서 게시글 좋아요 삭제, 댓글 삭제 추가
   - `boardCommentService.deleteAllBoardComment(board)` : 댓글 좋아요와 댓글 삭제 한 메소드에서 구현

### BoardCommentService
- `deleteAllBoardComment()` : 게시글 삭제 시 해당 게시글 댓글 완전 삭제
   - boardId 로부터 댓글을 모두 받아와 for문을 돌며 모든 댓글에 대한 댓글 좋아요 먼저 삭제 후 댓글 삭제하도록 하였습니다.

## 질문 및 이외 사항

- 더 좋은 방법이 있을까요?! 제 머리로는 이렇게 간단한 방법 밖에 안떠오르네요 ,,

## 이슈 번호

- close #133 
