### PR TITLE
Fix : 특정 멤버별 토론 댓글 조회

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/discussioncomment/DiscussionCommentController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussioncomment/DiscussionCommentController.java
@@ -2,6 +2,7 @@ package com.example.mssaem_backend.domain.discussioncomment;
 
 import com.example.mssaem_backend.domain.discussioncomment.dto.DiscussionCommentRequestDto.PostDiscussionCommentReq;
 import com.example.mssaem_backend.domain.discussioncomment.dto.DiscussionCommentResponseDto.DiscussionCommentSimpleInfo;
+import com.example.mssaem_backend.domain.discussioncomment.dto.DiscussionCommentResponseDto.DiscussionCommentSimpleInfoByMember;
 import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.global.common.dto.PageResponseDto;
 import com.example.mssaem_backend.global.config.security.auth.CurrentMember;
@@ -54,7 +55,6 @@ public class DiscussionCommentController {
                 commentId));
     }
 
-
     //댓글 삭제
     @DeleteMapping("/member/discussions/{discussionId}/comments/{commentId}")
     public ResponseEntity<Boolean> deleteDiscussionComment(@CurrentMember Member member,
@@ -62,5 +62,15 @@ public class DiscussionCommentController {
         @PathVariable(value = "commentId") Long commentId) {
         return ResponseEntity.ok(
             discussionCommentService.deleteDiscussionComment(member, discussionId, commentId));
+    }
+
+    //특정 멤버별 토론글 댓글 보기
+    @GetMapping("/discussions/comments")
+    public ResponseEntity<PageResponseDto<List<DiscussionCommentSimpleInfoByMember>>> findDiscussionCommentListByMemberId(
+        @RequestParam(value = "memberId") Long memberId, @RequestParam(value = "page") int page,
+        @RequestParam(value = "size") int size, @CurrentMember Member member) {
+        return ResponseEntity.ok(
+            discussionCommentService.findDiscussionCommentListByMemberId(memberId, page, size,
+                member));
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/discussioncomment/DiscussionCommentRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussioncomment/DiscussionCommentRepository.java
@@ -23,4 +23,6 @@ public interface DiscussionCommentRepository extends JpaRepository<DiscussionCom
     Boolean existsDiscussionCommentById(Long id);
 
     DiscussionComment findByIdAndDiscussionIdAndStateIsTrue(Long commentId, Long discussionId);
+
+    Page<DiscussionComment> findAllByMemberIdAndStateTrue(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/example/mssaem_backend/domain/discussioncomment/dto/DiscussionCommentResponseDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussioncomment/dto/DiscussionCommentResponseDto.java
@@ -14,7 +14,7 @@ public class DiscussionCommentResponseDto {
     @NoArgsConstructor
     public static class DiscussionCommentSimpleInfo {
         private Long commentId;
-        private String Content;
+        private String content;
         private Long likeCount;
         private Integer parentId;
         private String createdAt;
@@ -26,7 +26,7 @@ public class DiscussionCommentResponseDto {
         public DiscussionCommentSimpleInfo(MemberSimpleInfo memberSimpleInfo, DiscussionComment discussionComment,
             String createdAt , Boolean isEditAllowed , Boolean isLiked) {
             this.commentId = discussionComment.getId();
-            this.Content = discussionComment.getContent();
+            this.content = discussionComment.getContent();
             this.likeCount = discussionComment.getLikeCount();
             this.parentId = discussionComment.getParentId();
             this.memberSimpleInfo = memberSimpleInfo;
@@ -35,4 +35,35 @@ public class DiscussionCommentResponseDto {
             this.isLiked = isLiked;
         }
     }
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class DiscussionCommentSimpleInfoByMember {
+
+        private Long discussionId;
+        private Long commentId;
+        private String Content;
+        private Long likeCount;
+        private Integer parentId;
+        private String createdAt;
+        private Boolean isLiked; // 댓글 좋아요 눌렀는지 확인
+        private Boolean isAllowed; //삭제 또는 신고를 위한 내 댓글인지 확인
+        private MemberSimpleInfo memberSimpleInfo;
+
+        @Builder
+        public DiscussionCommentSimpleInfoByMember(MemberSimpleInfo memberSimpleInfo,
+            DiscussionComment discussionComment, String createdAt, Long discussionId, Boolean isAllowed,
+            Boolean isLiked) {
+            this.discussionId = discussionId;
+            this.commentId = discussionComment.getId();
+            this.Content = discussionComment.getContent();
+            this.likeCount = discussionComment.getLikeCount();
+            this.parentId = discussionComment.getParentId();
+            this.memberSimpleInfo = memberSimpleInfo;
+            this.createdAt = createdAt;
+            this.isAllowed = isAllowed;
+            this.isLiked = isLiked;
+        }
+    }
+
 }


### PR DESCRIPTION

## 요약

- 토론글 댓글 관련 API에서 빠진 부분을 추가했습니다.

## 상세 내용

- 특정 멤버별 토론 댓글 조회

## 이슈 번호

- closed #152 