### PR TITLE
게시글 댓글 삭제시 좋아요 삭제 / 토론글 댓글 관련 Refactor

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardComment.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardComment.java
@@ -51,6 +51,7 @@ public class BoardComment extends BaseTimeEntity {
 
     public void deleteBoardComment() {
         this.content = "삭제된 댓글입니다.";
+        this.likeCount = 0L;
         this.state = false;
     }
 

--- a/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentService.java
@@ -142,6 +142,8 @@ public class BoardCommentService {
         if (isMatch(member, boardComment.getMember())) {
             //같다면 삭제(삭제된 댓글입니다. 로 표시)
             boardComment.deleteBoardComment();
+            //댓글 삭제시 해당 댓글에 달린 좋아요 삭제
+            boardCommentLikeRepository.deleteAllByBoardComment(boardComment);
         } else {
             throw new BaseException(MemberErrorCode.INVALID_MEMBER);
         }
@@ -210,10 +212,10 @@ public class BoardCommentService {
     //게시글 삭제 시 해당 게시글 댓글 완전 삭제
     @Transactional
     public Boolean deleteAllBoardComment(Board board) {
-        List<BoardComment> comments = boardCommentRepository.findAllByBoardId(board.getId());
+        List<BoardComment> boardComments = boardCommentRepository.findAllByBoardId(board.getId());
         //모든 댓글에 대한 댓글 좋아요 먼저 삭제
-        for (BoardComment comment : comments) {
-            boardCommentLikeRepository.deleteAllByBoardComment(comment);
+        for (BoardComment boardComment : boardComments) {
+            boardCommentLikeRepository.deleteAllByBoardComment(boardComment);
         }
         // 게시글에 대한 모든 댓글 삭제
         boardCommentRepository.deleteAllByBoard(board);

--- a/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionService.java
@@ -9,6 +9,7 @@ import com.example.mssaem_backend.domain.discussion.dto.DiscussionResponseDto.Di
 import com.example.mssaem_backend.domain.discussion.dto.DiscussionResponseDto.DiscussionHistory;
 import com.example.mssaem_backend.domain.discussion.dto.DiscussionResponseDto.DiscussionSimpleInfo;
 import com.example.mssaem_backend.domain.discussioncomment.DiscussionCommentRepository;
+import com.example.mssaem_backend.domain.discussioncomment.DiscussionCommentService;
 import com.example.mssaem_backend.domain.discussionoption.DiscussionOption;
 import com.example.mssaem_backend.domain.discussionoption.DiscussionOptionRepository;
 import com.example.mssaem_backend.domain.discussionoption.DiscussionOptionService;
@@ -50,6 +51,7 @@ public class DiscussionService {
     private final BadgeRepository badgeRepository;
     private final NotificationService notificationService;
     private final MemberRepository memberRepository;
+    private final DiscussionCommentService discussionCommentService;
 
 
     // HOT 토론글 더보기 조회
@@ -258,6 +260,8 @@ public class DiscussionService {
         match(member, discussion.getMember());
 
         discussionOptionService.deleteOption(discussion);
+        //토론글 삭제 시 모든 댓글,댓글 좋아요 삭제
+        discussionCommentService.deleteAllDiscussionComment(discussion);
         discussion.deleteDiscussion();
 
         return "토론글 삭제완료";

--- a/src/main/java/com/example/mssaem_backend/domain/discussioncomment/DiscussionComment.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussioncomment/DiscussionComment.java
@@ -62,6 +62,7 @@ public class DiscussionComment extends BaseTimeEntity {
 
     public void deleteDiscussionComment() {
         this.content = "삭제된 댓글입니다.";
+        this.likeCount = 0L;
         this.state = false;
     }
 

--- a/src/main/java/com/example/mssaem_backend/domain/discussioncomment/DiscussionCommentRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussioncomment/DiscussionCommentRepository.java
@@ -2,6 +2,7 @@ package com.example.mssaem_backend.domain.discussioncomment;
 
 import com.example.mssaem_backend.domain.discussion.Discussion;
 import com.example.mssaem_backend.domain.member.Member;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -25,4 +26,8 @@ public interface DiscussionCommentRepository extends JpaRepository<DiscussionCom
     DiscussionComment findByIdAndDiscussionIdAndStateIsTrue(Long commentId, Long discussionId);
 
     Page<DiscussionComment> findAllByMemberIdAndStateTrue(Long memberId, Pageable pageable);
+
+    List<DiscussionComment> findAllByDiscussion(Discussion discussion);
+
+    List<DiscussionComment> deleteAllByDiscussion(Discussion discussion);
 }

--- a/src/main/java/com/example/mssaem_backend/domain/discussioncomment/DiscussionCommentService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussioncomment/DiscussionCommentService.java
@@ -206,4 +206,18 @@ public class DiscussionCommentService {
                     .collect(Collectors.toList()), viewer)
         );
     }
+
+    //토론글 삭제 시 해당 토론글 댓글 완전 삭제
+    @Transactional
+    public Boolean deleteAllDiscussionComment(Discussion discussion) {
+        List<DiscussionComment> discussionComments = discussionCommentRepository.findAllByDiscussion(
+            discussion);
+        //모든 댓글에 대한 댓글 좋아요 먼저 삭제
+        for (DiscussionComment discussionComment : discussionComments) {
+            discussionCommentLikeRepository.deleteAllByDiscussionComment(discussionComment);
+        }
+        //토론글에 대한 모든 댓글 삭제
+        discussionCommentRepository.deleteAllByDiscussion(discussion);
+        return true;
+    }
 }


### PR DESCRIPTION
## 요약

- 게시글 댓글을 삭제할 때 해당 댓글 좋아요를 삭제
- 토론글 댓글 관련 Refactor
  - 토론글 삭제시 댓글 좋아요 삭제
  - 토론글 삭제시 댓글 모두 삭제

## 상세 내용

### BoardCommentService
- `boardCommentLikeRepository.deleteAllByBoardComment(boardComment)` : 댓글 삭제할 때 해당 댓글 좋아요 모두 삭제

### DiscussionCommentService
- `deleteAllDiscussionComment()` : 토론글 삭제할 때 해당 토론글 댓글 좋아요, 댓글 모두 삭제

## 질문 및 이외 사항

- 게시글 삭제시 로직과 동일합니다.

## 이슈 번호

- close #155 
