### PR TITLE
멤버 프로필 관련 API

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/badge/Badge.java
+++ b/src/main/java/com/example/mssaem_backend/domain/badge/Badge.java
@@ -33,4 +33,12 @@ public class Badge extends BaseTimeEntity {
     private Member member;
 
     private boolean state; // true : 대표
+
+    public void changeStateTrue() {
+        this.state = true;
+    }
+
+    public void changeStateFalse() {
+        this.state = false;
+    }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/badge/BadgeRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/badge/BadgeRepository.java
@@ -17,4 +17,7 @@ public interface BadgeRepository extends JpaRepository<Badge, Long> {
     Optional<String> findNameByIdAndMember(@Param("id") Long id, @Param("member") Member member);
 
     Optional<List<Badge>> findAllByMember(@Param("member") Member member);
+
+    Optional<Badge> findByMemberAndStateTrue(Member member);
+    Optional<Badge> findByIdAndMember(Long id, Member member);
 }

--- a/src/main/java/com/example/mssaem_backend/domain/badge/BadgeService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/badge/BadgeService.java
@@ -3,8 +3,15 @@ package com.example.mssaem_backend.domain.badge;
 import com.example.mssaem_backend.domain.badge.dto.BadgeResponse;
 import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.domain.badge.dto.BadgeResponse.BadgeInfo;
+import com.example.mssaem_backend.domain.member.MemberRepository;
+import com.example.mssaem_backend.domain.member.MemberService;
+import com.example.mssaem_backend.global.config.exception.BaseException;
+import com.example.mssaem_backend.global.config.exception.errorCode.BadgeErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,5 +34,27 @@ public class BadgeService {
             badges.forEach(badge -> result.add(new BadgeInfo(badge.getId(), badge.getName())));
         }
         return result;
+    }
+
+    /**
+     * member와 바꾸려는 대표 뱃지로 바꾸려는 badgeId를 받아서 유효성 검사 후 바꿔주는 함수
+     */
+    @Transactional(rollbackFor = Exception.class, propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+    public String changeRepresentativeBadge(Member member, Long badgeId) {
+        if (badgeId != null) {
+            // 새로운 뱃지 받아오기, 멤버가 획득한 뱃지가 맞는지 유효성 검사
+            Badge newBadge = badgeRepository.findByIdAndMember(badgeId, member)
+                    .orElseThrow(() -> new BaseException(BadgeErrorCode.EMPTY_BADGE));
+            // 예전 뱃지 받아오기
+            Badge oldBadge = badgeRepository.findByMemberAndStateTrue(member).orElse(null);
+            // 예전 뱃지가 존재한다면 false 로 설정
+            if (oldBadge != null) {
+                oldBadge.changeStateFalse();
+            }
+            // 새로운 뱃지를 true 로 변경
+            newBadge.changeStateTrue();
+            return newBadge.getName();
+        }
+        return null;
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/badge/BadgeService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/badge/BadgeService.java
@@ -31,7 +31,7 @@ public class BadgeService {
         List<Badge> badges = badgeRepository.findAllByMember(member).orElse(null);
         List<BadgeInfo> result = new ArrayList<>();
         if (badges != null) {
-            badges.forEach(badge -> result.add(new BadgeInfo(badge.getId(), badge.getName())));
+            badges.forEach(badge -> result.add(new BadgeInfo(badge.getId(), badge.getName(), badge.isState())));
         }
         return result;
     }

--- a/src/main/java/com/example/mssaem_backend/domain/badge/dto/BadgeResponse.java
+++ b/src/main/java/com/example/mssaem_backend/domain/badge/dto/BadgeResponse.java
@@ -12,5 +12,6 @@ public class BadgeResponse {
     public static class BadgeInfo {
         private Long id;
         private String name;
+        private boolean status;
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/mbti/MbtiEnum.java
+++ b/src/main/java/com/example/mssaem_backend/domain/mbti/MbtiEnum.java
@@ -1,6 +1,28 @@
 package com.example.mssaem_backend.domain.mbti;
 
 public enum MbtiEnum {
-    INFJ, INFP, ISFJ, ISFP, ISTP, ISTJ, INTP, INTJ,
-    ENTP, ESTJ, ESTP, ENFP, ESFJ, ENTJ, ENFJ, ESFP
+    INFJ("https://mssaem-bucket.s3.ap-northeast-2.amazonaws.com/3070b9d0-0658-4c9b-b34a-47320350a1d5.png"),
+    INFP("https://mssaem-bucket.s3.ap-northeast-2.amazonaws.com/a88cb201-17ce-4f58-9e6c-3ee526af4ad7.png"),
+    ISFJ("https://mssaem-bucket.s3.ap-northeast-2.amazonaws.com/f23354e8-7710-42a3-af2e-c4a3ea27222e.png"),
+    ISFP("https://mssaem-bucket.s3.ap-northeast-2.amazonaws.com/2aa65ede-6304-44f0-a16e-5e228b597154.png"),
+    ISTP("https://mssaem-bucket.s3.ap-northeast-2.amazonaws.com/0b30af0f-628e-4d6e-a2ef-fad0ff06d650.png"),
+    ISTJ("https://mssaem-bucket.s3.ap-northeast-2.amazonaws.com/ab75f543-2f73-4095-8308-c71394e84b33.png"),
+    INTP("https://mssaem-bucket.s3.ap-northeast-2.amazonaws.com/5335e604-efca-4afc-8298-e5905b0f68b4.png"),
+    INTJ("https://mssaem-bucket.s3.ap-northeast-2.amazonaws.com/a4b75267-0599-4617-a037-8a531a18a24e.png"),
+    ENTP("https://mssaem-bucket.s3.ap-northeast-2.amazonaws.com/7321c26b-e29c-4763-bdeb-2f5de57eed2d.png"),
+    ESTJ("https://mssaem-bucket.s3.ap-northeast-2.amazonaws.com/d22f199a-2b2a-410e-a4b5-ca51f86459ee.png"),
+    ESTP("https://mssaem-bucket.s3.ap-northeast-2.amazonaws.com/0d3acd01-aedd-486a-bb88-6645319959eb.png"),
+    ENFP("https://mssaem-bucket.s3.ap-northeast-2.amazonaws.com/309c8545-9063-4245-aba9-17cbf89f4e6f.png"),
+    ESFJ("https://mssaem-bucket.s3.ap-northeast-2.amazonaws.com/fef3e04f-f7f2-4ddb-9bf5-08d6c5a6a4b8.png"),
+    ENTJ("https://mssaem-bucket.s3.ap-northeast-2.amazonaws.com/8ef4af6b-f5bb-4cbe-a525-a59e595eac84.png"),
+    ENFJ("https://mssaem-bucket.s3.ap-northeast-2.amazonaws.com/bea7ba0f-6d9e-45d2-8d3e-2a219a9b3aa2.png"),
+    ESFP("https://mssaem-bucket.s3.ap-northeast-2.amazonaws.com/f440d2f9-7d06-4ca7-a907-7598b173fa3e.png");
+
+    private final String profileUrl;
+
+    MbtiEnum(String profileUrl) {
+        this.profileUrl = profileUrl;
+    }
+
+    public String getProfileUrl() { return profileUrl; }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/member/Member.java
+++ b/src/main/java/com/example/mssaem_backend/domain/member/Member.java
@@ -52,6 +52,9 @@ public class Member extends BaseTimeEntity {
 
     private String badgeName;
 
+    @Transient
+    private boolean defaultProfile = true;
+
     public void changeRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
@@ -74,6 +77,7 @@ public class Member extends BaseTimeEntity {
         this.mbti = mbti;
         this.caseSensitivity = caseSensitivity;
         this.profileImageUrl = mbti.getProfileUrl();
+        System.out.println("프로필 이미지는 " + this.profileImageUrl);
         this.refreshToken = "";
         this.report = 0;
         this.role = Role.ROLE_MEMBER;
@@ -81,13 +85,18 @@ public class Member extends BaseTimeEntity {
 
     public void modifyMember(String nickName, String introduction, String profileImageUrl,
                              MbtiEnum mbti, String caseSensitivity, String badgeName) {
+        // MBTI 변경 시 프로필 사진이 디폴트라면 프로필 사진도 같이 변경
+        if (mbti != null) {
+            this.mbti = mbti;
+            if (this.defaultProfile) {
+                this.profileImageUrl = mbti.getProfileUrl();
+            }
+        }
         this.nickName = nickName != null ? nickName : this.nickName;
         this.introduction = introduction != null ? introduction : this.introduction;
         this.profileImageUrl = profileImageUrl != null ? profileImageUrl : this.profileImageUrl;
-        this.mbti = mbti != null ? mbti : this.mbti;
         this.caseSensitivity = caseSensitivity != null ? caseSensitivity : this.caseSensitivity;
         this.badgeName = badgeName != null ? badgeName : this.badgeName;
-
     }
 
     public Integer increaseReport() {
@@ -96,6 +105,10 @@ public class Member extends BaseTimeEntity {
 
     public void updateStatus() {
         this.status = false;
+    }
+
+    public void changeFalseDefaultProfile() {
+        this.defaultProfile = false;
     }
 
 }

--- a/src/main/java/com/example/mssaem_backend/domain/member/Member.java
+++ b/src/main/java/com/example/mssaem_backend/domain/member/Member.java
@@ -111,4 +111,9 @@ public class Member extends BaseTimeEntity {
         this.defaultProfile = false;
     }
 
+    public void deleteProfile() {
+        this.profileImageUrl = this.mbti.getProfileUrl();
+        this.defaultProfile = true;
+    }
+
 }

--- a/src/main/java/com/example/mssaem_backend/domain/member/Member.java
+++ b/src/main/java/com/example/mssaem_backend/domain/member/Member.java
@@ -73,6 +73,7 @@ public class Member extends BaseTimeEntity {
         this.nickName = nickName;
         this.mbti = mbti;
         this.caseSensitivity = caseSensitivity;
+        this.profileImageUrl = mbti.getProfileUrl();
         this.refreshToken = "";
         this.report = 0;
         this.role = Role.ROLE_MEMBER;
@@ -88,7 +89,6 @@ public class Member extends BaseTimeEntity {
         this.badgeName = badgeName != null ? badgeName : this.badgeName;
 
     }
-
 
     public Integer increaseReport() {
         return this.report++;

--- a/src/main/java/com/example/mssaem_backend/domain/member/MemberController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/member/MemberController.java
@@ -104,4 +104,12 @@ public class MemberController {
         return new ResponseEntity<>(memberService.getMemberInfo(member), HttpStatus.OK);
     }
 
+    /**
+     * [DELETE] 프로필 이미지 삭제
+     */
+    @DeleteMapping("/member/profile")
+    public ResponseEntity<String> deleteProfileImage(@CurrentMember Member member) {
+        return new ResponseEntity<>(memberService.deleteProfileImage(member), HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/com/example/mssaem_backend/domain/member/MemberController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/member/MemberController.java
@@ -75,7 +75,7 @@ public class MemberController {
     @PatchMapping("/member/profile")
     public ResponseEntity<String> modifyProfile(
             @CurrentMember Member member, @RequestPart(value = "modifyProfile") ModifyProfile modifyProfile,
-            @RequestPart(value = "image", required = false) List<MultipartFile> multipartFile) {
+            @RequestPart(value = "image", required = false) MultipartFile multipartFile) {
         return new ResponseEntity<>(memberService.modifyProfile(member, modifyProfile, multipartFile), HttpStatus.OK);
     }
 

--- a/src/main/java/com/example/mssaem_backend/domain/member/MemberController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/member/MemberController.java
@@ -4,7 +4,7 @@ import com.example.mssaem_backend.domain.member.dto.MemberRequestDto.ModifyProfi
 import com.example.mssaem_backend.domain.member.dto.MemberRequestDto.CheckNickName;
 import com.example.mssaem_backend.domain.member.dto.MemberRequestDto.RegisterMember;
 import com.example.mssaem_backend.domain.member.dto.MemberRequestDto.SocialLoginToken;
-import com.example.mssaem_backend.domain.member.dto.MemberResponseDto;
+import com.example.mssaem_backend.domain.member.dto.MemberResponseDto.MemberSimpleInfo;
 import com.example.mssaem_backend.domain.member.dto.MemberResponseDto.MemberProfileInfo;
 import com.example.mssaem_backend.domain.member.dto.MemberResponseDto.CheckNickNameRes;
 import com.example.mssaem_backend.domain.member.dto.MemberResponseDto.TeacherInfo;
@@ -94,6 +94,14 @@ public class MemberController {
     @PatchMapping("/member/refresh")
     public ResponseEntity<TokenInfo> refreshLogin(@CurrentMember Member member) {
         return new ResponseEntity<>(memberService.refreshAccessToken(member), HttpStatus.OK);
+    }
+
+    /**
+     * [GET] 로그인한 유저 정보 조회
+     */
+    @GetMapping("/member/info")
+    public ResponseEntity<MemberSimpleInfo> getCurrentMemberInfo(@CurrentMember Member member) {
+        return new ResponseEntity<>(memberService.getMemberInfo(member), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/example/mssaem_backend/domain/member/MemberService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/member/MemberService.java
@@ -139,19 +139,15 @@ public class MemberService {
         return teacherInfos;
     }
 
-    public String modifyProfile(Member currentMember, ModifyProfile modifyProfile, List<MultipartFile> multipartFile) {
+    public String modifyProfile(Member currentMember, ModifyProfile modifyProfile, MultipartFile multipartFile) {
         Member member = memberRepository.findById(currentMember.getId())
                 .orElseThrow(() -> new BaseException(MemberErrorCode.EMPTY_MEMBER));
 
         String profileImageUrl = "";
         if (multipartFile != null) {
-            //현재 저장된 이미지 삭제
-            if(member.getProfileImageUrl() != null) {
-                s3Service.deleteFile(s3Service.parseFileName(member.getProfileImageUrl()));
-            }
-            //새로운 이미지 업로드
-            List<S3Result> s3Results = s3Service.uploadFile(multipartFile);
-            profileImageUrl = s3Results.get(0).getImgUrl();
+            // 기존 이미지 삭제 후 새로운 이미지 업로드
+            s3Service.deleteFile(s3Service.parseFileName(member.getProfileImageUrl()));
+            profileImageUrl = s3Service.uploadImage(multipartFile);
         }
 
         member.modifyMember(modifyProfile.getNickName(), modifyProfile.getIntroduction(),

--- a/src/main/java/com/example/mssaem_backend/domain/member/MemberService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/member/MemberService.java
@@ -182,6 +182,12 @@ public class MemberService {
         return new MemberSimpleInfo(member);
     }
 
+    public String deleteProfileImage(Member member) {
+        member.deleteProfile();
+        save(member);
+        return "삭제 완료";
+    }
+
     private String uploadFile(Member member, MultipartFile multipartFile) {
         if (multipartFile != null) {
             // 기본 이미지가 아니라면 기존 이미지 삭제 후 새로운 이미지 업로드, 기본 이미지가 삭제 되지 않기 위함

--- a/src/main/java/com/example/mssaem_backend/domain/member/MemberService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/member/MemberService.java
@@ -11,6 +11,7 @@ import com.example.mssaem_backend.domain.member.dto.MemberRequestDto.ModifyProfi
 import com.example.mssaem_backend.domain.member.dto.MemberRequestDto.CheckNickName;
 import com.example.mssaem_backend.domain.member.dto.MemberRequestDto.RegisterMember;
 import com.example.mssaem_backend.domain.member.dto.MemberRequestDto.SocialLoginToken;
+import com.example.mssaem_backend.domain.member.dto.MemberResponseDto.MemberSimpleInfo;
 import com.example.mssaem_backend.domain.member.dto.MemberResponseDto.MemberProfileInfo;
 import com.example.mssaem_backend.domain.member.dto.MemberResponseDto.CheckNickNameRes;
 import com.example.mssaem_backend.domain.member.dto.MemberResponseDto.TeacherInfo;
@@ -175,6 +176,10 @@ public class MemberService {
                 .accessToken(jwtTokenProvider.generateAccessToken(member.getId()))
                 .refreshToken(member.getRefreshToken())
                 .build();
+    }
+
+    public MemberSimpleInfo getMemberInfo(Member member) {
+        return new MemberSimpleInfo(member);
     }
 
     private String uploadFile(Member member, MultipartFile multipartFile) {

--- a/src/main/java/com/example/mssaem_backend/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/member/dto/MemberResponseDto.java
@@ -43,6 +43,14 @@ public class MemberResponseDto {
             this.badge = badge;
             this.profileImgUrl = member.getProfileImageUrl();
         }
+
+        public MemberSimpleInfo(Member member) {
+            this.id = member.getId();
+            this.nickName = member.getNickName();
+            this.mbti = member.getDetailMbti();
+            this.badge = member.getBadgeName();
+            this.profileImgUrl = member.getProfileImageUrl();
+        }
     }
 
     @Getter

--- a/src/main/java/com/example/mssaem_backend/global/config/exception/errorCode/BadgeErrorCode.java
+++ b/src/main/java/com/example/mssaem_backend/global/config/exception/errorCode/BadgeErrorCode.java
@@ -1,0 +1,16 @@
+package com.example.mssaem_backend.global.config.exception.errorCode;
+
+import com.example.mssaem_backend.global.config.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum BadgeErrorCode implements ErrorCode {
+    EMPTY_BADGE("BADGE_001", "유효하지 않은 뱃지입니다.", HttpStatus.UNAUTHORIZED);
+
+    private final String errorCode;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/example/mssaem_backend/global/config/security/oauth/SocialLoginService.java
+++ b/src/main/java/com/example/mssaem_backend/global/config/security/oauth/SocialLoginService.java
@@ -100,7 +100,7 @@ public class SocialLoginService {
                 .uri(uriBuilder -> uriBuilder
                         .path("/v1/nid/me")
                         .build())
-                .header("Authorization", "Bearer" + accessToken)
+                .header("Authorization", "Bearer " + accessToken)
                 .retrieve().bodyToMono(JSONObject.class).block();
 
         if (response == null) {


### PR DESCRIPTION
## 요약

- [MBTI 별 기본 프로필 이미지 추가](https://github.com/Help-M-Ssaem/back-end/commit/58ea2855566748b06b08725065ccb5fad274ed50)
- [프로필 조회 API에서 프로필 사진, 대표 뱃지 변경 로직 추가](https://github.com/Help-M-Ssaem/back-end/commit/4b7e166c8ba199f3d60e50ca058c94f5e29f64b2)
- [BadgeInfo DTO에 status 값 추가](https://github.com/Help-M-Ssaem/back-end/commit/883b351a6da0e1a35b425f1740750470241d64dc)
- [현재 로그인한 멤버 조회 API](https://github.com/Help-M-Ssaem/back-end/commit/7bdf4e9b93ea5915021dde3e41076ed3ad15b2bf)
- [프로필 이미지 삭제 API](https://github.com/Help-M-Ssaem/back-end/commit/b396643c30af4b1689db93a8822f2c2988fce0fe)

## 상세 내용

- 아래 부분은 함수 하나로 통일할 수도 있었지만 실수하기 쉬운 부분 같아서 의도를 더 잘 나타내기 위해 이렇게 썼습니다.

```
    public void changeStateTrue() {
        this.state = true;
    }

    public void changeStateFalse() {
        this.state = false;
    }
```

- 기본 이미지인지 아닌지를 나타내는 필드 값을 추가했습니다. @Transient 어노테이션을 사용할 경우 엔티티에서는 사용할 수 있지만 테이블에 컬럼은 생기지 않습니다.
```
    @Transient
    private boolean defaultProfile = true;
```
- 회원가입 할 때 기본 프로필 사진이 MBTI에 따라 설정됩니다.
- 프로필 이미지를 삭제하면, 현재 설정되어 있는 MBTI에 해당하는 기본 프로필 사진으로 설정됩니다.
## 질문 및 이외 사항

- 

## 이슈 번호

-
