### PR TITLE
HOT 기준 변경

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardRepository.java
@@ -4,6 +4,7 @@ import com.example.mssaem_backend.domain.mbti.MbtiEnum;
 import com.example.mssaem_backend.domain.member.Member;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,13 +12,21 @@ import org.springframework.data.repository.query.Param;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
+    // HOT 게시글 조회
+    Page<Board> findBoardsByLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(Long likeCount,
+        PageRequest pageRequest);
+
+
     //boardId가 입력되지 않으면 전체 게시글 조회, 입력되면 해당 게시글만 제외하고 전체 조회
     @Query("SELECT b FROM Board b WHERE b.state = true AND (:boardId IS NULL OR b.id <> :boardId) order by b.createdAt desc ")
-    Page<Board> findAllByStateIsTrueAndIdOrderByCreatedAtDesc(@Param("boardId") Long boardId, Pageable pageable);
+    Page<Board> findAllByStateIsTrueAndIdOrderByCreatedAtDesc(@Param("boardId") Long boardId,
+        Pageable pageable);
 
-    Page<Board> findAllByStateIsTrueAndMbtiOrderByCreatedAtDesc(MbtiEnum mbtiEnum, Pageable pageable);
+    Page<Board> findAllByStateIsTrueAndMbtiOrderByCreatedAtDesc(MbtiEnum mbtiEnum,
+        Pageable pageable);
 
-    Page<Board> findAllByMemberIdAndStateIsTrueOrderByCreatedAtDesc(Long memberId, Pageable pageable);
+    Page<Board> findAllByMemberIdAndStateIsTrueOrderByCreatedAtDesc(Long memberId,
+        Pageable pageable);
 
     // 검색하기
     @Query("SELECT b FROM Board b WHERE"
@@ -37,14 +46,13 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     Board findByMemberAndIdAndStateIsTrue(Member member, Long id);
 
 
-
     //내용, 제목, 닉네임 별 검색어 한 번에 조회
     @Query(value = "select b from Board b join fetch b.member"
         + " where (lower(b.title) like lower(concat('%', :keyword, '%'))) "
         + "or (lower(b.content) like lower(concat('%', :keyword, '%'))) "
         + "or (lower(b.member.nickName) like lower(concat('%', :keyword, '%'))) "
         + "and b.state = true order by b.createdAt desc",
-        countQuery = "select count(b) from Board b" )
+        countQuery = "select count(b) from Board b")
     Page<Board> findByKeyword(@Param("keyword") String keyword, Pageable pageable);
 
     Optional<Board> findByIdAndStateIsTrue(Long id);

--- a/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionController.java
@@ -33,7 +33,7 @@ public class DiscussionController {
     @GetMapping("/discussions/hot")
     public ResponseEntity<PageResponseDto<List<DiscussionSimpleInfo>>> findHotDiscussionList(
         @CurrentMember Member member, @RequestParam int page, @RequestParam int size) {
-        return ResponseEntity.ok(discussionService.findHotDiscussionList(member, page, size));
+        return ResponseEntity.ok(discussionService.findHotDiscussionsMore(member, page, size));
     }
 
     /**
@@ -42,7 +42,7 @@ public class DiscussionController {
     @GetMapping("/discussions/home")
     public ResponseEntity<List<DiscussionSimpleInfo>> findHotDiscussionListForHome(
         @CurrentMember Member member) {
-        return ResponseEntity.ok(discussionService.findHotDiscussionListForHome(member));
+        return ResponseEntity.ok(discussionService.findHotDiscussionsForHome(member));
     }
 
     /**
@@ -131,6 +131,7 @@ public class DiscussionController {
         @CurrentMember Member member,
         @RequestParam(required = false) Long memberId, @RequestParam(value = "page") int page,
         @RequestParam(value = "size") int size) {
-        return ResponseEntity.ok(discussionService.findDiscussionsByMemberId(member, memberId, page, size));
+        return ResponseEntity.ok(
+            discussionService.findDiscussionsByMemberId(member, memberId, page, size));
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionRepository.java
@@ -1,7 +1,6 @@
 package com.example.mssaem_backend.domain.discussion;
 
 import com.example.mssaem_backend.domain.member.Member;
-import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -12,11 +11,9 @@ import org.springframework.data.repository.query.Param;
 
 public interface DiscussionRepository extends JpaRepository<Discussion, Long> {
 
-    // 생성된지 3일 이내이고, 참여자수가 10명 이상인 토론글들을 참여자수를 기준으로 내림차순 정렬
-    @Query(value = "SELECT d FROM Discussion d WHERE d.createdAt >= :threeDaysAgo AND d.participantCount >= 1 AND d.state = true ORDER BY d.participantCount DESC")
-    Page<Discussion> findDiscussionWithMoreThanTenParticipantsInLastThreeDaysAndStateTrue(
-        @Param("threeDaysAgo") LocalDateTime threeDaysAgo, PageRequest pageRequest);
-
+    // HOT 토론 조회
+    Page<Discussion> findDiscussionByParticipantCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
+        Long participantCount, PageRequest pageRequest);
 
     @Query("SELECT d FROM Discussion d WHERE"
         + "(    (:type = 0 AND (LOWER(d.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(d.content) LIKE LOWER(CONCAT('%', :keyword, '%'))))"
@@ -44,7 +41,9 @@ public interface DiscussionRepository extends JpaRepository<Discussion, Long> {
 
     @Query(value = "SELECT SUM(d.participantCount) FROM Discussion d WHERE d.member = :member AND d.state = true")
     Long sumParticipantCountByMember(@Param("member") Member member);
+
     Page<Discussion> findByStateTrueOrderByCreatedAtDesc(PageRequest pageRequest);
 
-    Page<Discussion> findAllByMemberAndStateIsTrueOrderByCreatedAtDesc(Member member, Pageable pageable);
+    Page<Discussion> findAllByMemberAndStateIsTrueOrderByCreatedAtDesc(Member member,
+        Pageable pageable);
 }

--- a/src/main/java/com/example/mssaem_backend/domain/like/LikeRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/like/LikeRepository.java
@@ -2,20 +2,12 @@ package com.example.mssaem_backend.domain.like;
 
 import com.example.mssaem_backend.domain.board.Board;
 import com.example.mssaem_backend.domain.member.Member;
-import java.time.LocalDateTime;
 import java.util.List;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
-
-    // 3일 동안 10개 이상 좋아요를 받은 게시물들을 3일 동안 받은 좋아요수 기준으로 내림차순 정렬
-    @Query(value = "SELECT l.board FROM Like l WHERE l.createdAt >= :threeDaysAgo AND l.board.state = true AND l.state = true GROUP BY l.board HAVING COUNT(l.board.id) >= 1 ORDER BY COUNT(l.board.id) DESC")
-    Page<Board> findBoardsWithMoreThanTenLikesInLastThreeDaysAndStateTrue(
-        @Param("threeDaysAgo") LocalDateTime threeDaysAgo, PageRequest pageRequest);
 
     Boolean existsLikeByMemberAndStateIsTrueAndBoard(Member member, Board board);
 


### PR DESCRIPTION
## 요약

- HOT의 기준을 좋아요 개수/참여자 수가 10 이상인 게시물 중 생성일을 기준으로 내림차순 정렬했을 때의 상위 게시물로 변경

## 상세 내용
### BoardRepository, DiscussionRepository
- HOT 게시물 조회하는 메소드를 `findBoardsByLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc()` 로 변경
- HOT 토론 조회하는 메소드를 `findDiscussionsByParticipantCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc()`로 변경
### BoardService
- HOT 게시물의 조건인 **좋아요 개수**의 값을 static final 변수로 관리 => `likeCountStandard`
- HOT 게시물 조회하는 모든 메소드에서 `likeRepository`를 통해 조회해오는 부분을 `boardRepository`에 추가한 메소드를 호출해서 조회
- 3HOT의 토론 부분은 `DiscussionService`의 메소드를 호출해서 조회
    - HOT 토론의 조건인 **참여자수**의 값을 `BoardService`에서 가지고 있는 것보다 `DiscussionService`에서 가지고 있는 것이 낫다고 판단해 `DiscussionService`에 HOT 토론을 조회해오는 메소드를 따로 분리함
### DiscussionService
- HOT 토론의 조건인 **참여자수**의 값을 static final 변수로 관리 => `participantCountStandard`
- HOT 토론을 조회만 해오는 로직을 한 메소드로 분리 (이유는 위 내용 참고)
    - 메소드 구분을 위해 이름 변경
    - `findHotDiscussions` : HOT 토론 조회만 해오는 메소드 
    - `findHotDiscussionsMore` : HOT 토론 더보기 
    - `findHotDiscussionsForHome` : 홈 화면의 HOT 토론 
## 질문 및 이외 사항

- 이게 새로운 기능 추가도 아니고 결과가 변동되니 리팩토링도 아니라 어떤 Label을 지정해야 할지 모르겠어요😅 

## 이슈 번호

- #168
