### PR TITLE
알림 조회시 type 명시 및 수정

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentService.java
@@ -92,33 +92,35 @@ public class BoardCommentService {
 
         //만약 코멘트가 존재한다면 그 댓글에 대댓글
         if (boardCommentRepository.existsBoardCommentById(commentId)) {
-            BoardComment newBoardComment = boardCommentRepository.save(
+            boardCommentRepository.save(
                 new BoardComment(
                     postBoardCommentReq.getContent(),
                     member,
                     board,
                     commentId.intValue()));
+
             // 글을 쓴 멤버가 아닌 멤버가 댓글을 달 때만 알림 등록
-            if (!board.getId().equals(member.getId())) {
+            if (!board.getMember().getId().equals(member.getId())) {
                 notificationService.createNotification(
-                    newBoardComment.getId(),
+                    board.getId(),
                     postBoardCommentReq.getContent(),
-                    TypeEnum.REPLY_OF_COMMENT,
+                    TypeEnum.BOARD_REPLY_OF_COMMENT,
                     board.getMember()
                 );
             }
         } else { //존재하지 않다면 새로운 댓글
-            BoardComment newBoardComment = boardCommentRepository.save(
+            boardCommentRepository.save(
                 new BoardComment(
                     postBoardCommentReq.getContent(),
                     member,
                     board,
                     0)
             );
+
             // 글을 쓴 멤버가 아닌 멤버가 댓글을 달 때만 알림 등록
-            if (!board.getId().equals(member.getId())) {
+            if (!board.getMember().getId().equals(member.getId())) {
                 notificationService.createNotification(
-                    newBoardComment.getId(),
+                    board.getId(),
                     postBoardCommentReq.getContent(),
                     TypeEnum.BOARD_COMMENT,
                     board.getMember()

--- a/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentService.java
@@ -16,6 +16,7 @@ import com.example.mssaem_backend.domain.notification.NotificationService;
 import com.example.mssaem_backend.domain.notification.TypeEnum;
 import com.example.mssaem_backend.global.common.dto.PageResponseDto;
 import com.example.mssaem_backend.global.config.exception.BaseException;
+import com.example.mssaem_backend.global.config.exception.errorCode.BoardCommentErrorCode;
 import com.example.mssaem_backend.global.config.exception.errorCode.BoardErrorCode;
 import com.example.mssaem_backend.global.config.exception.errorCode.MemberErrorCode;
 import java.util.ArrayList;
@@ -99,13 +100,28 @@ public class BoardCommentService {
                     board,
                     commentId.intValue()));
 
-            // 글을 쓴 멤버가 아닌 멤버가 댓글을 달 때만 알림 등록
+            // 게시글 작성자와 대댓글 작성자가 일치하지 않을 때에만 알림 전송
             if (!board.getMember().getId().equals(member.getId())) {
+                // 대댓글이 달린 게시글을 작성한 유저에게 알림 전송
+                notificationService.createNotification(
+                    board.getId(),
+                    postBoardCommentReq.getContent(),
+                    TypeEnum.BOARD_COMMENT,
+                    board.getMember()
+                );
+            }
+            // 부모 댓글 조회
+            BoardComment parentComment = boardCommentRepository.findById(commentId)
+                .orElseThrow(() -> new BaseException(
+                    BoardCommentErrorCode.EMPTY_BOARD_COMMENT));
+            // 부모 댓글 작성자와 대댓글 작성자가 일치하지 않을 때에만 알림 전송
+            if (!parentComment.getMember().getId().equals(member.getId())) {
+                // 대댓글의 부모 댓글을 작성한 유저에게 알림 전송
                 notificationService.createNotification(
                     board.getId(),
                     postBoardCommentReq.getContent(),
                     TypeEnum.BOARD_REPLY_OF_COMMENT,
-                    board.getMember()
+                    parentComment.getMember()
                 );
             }
         } else { //존재하지 않다면 새로운 댓글

--- a/src/main/java/com/example/mssaem_backend/domain/discussioncomment/DiscussionCommentService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussioncomment/DiscussionCommentService.java
@@ -95,33 +95,35 @@ public class DiscussionCommentService {
 
         //만약 코멘트가 존재한다면 그 댓글에 대댓글
         if (discussionCommentRepository.existsDiscussionCommentById(commentId)) {
-            DiscussionComment newDiscussionComment = discussionCommentRepository.save(
+            discussionCommentRepository.save(
                 new DiscussionComment(
                     postDiscussionCommentReq.getContent(),
                     member,
                     discussion,
                     commentId.intValue()));
+
             // 글을 쓴 멤버가 아닌 멤버가 댓글을 달 때만 알림 등록
-            if (!discussion.getId().equals(member.getId())) {
+            if (!discussion.getMember().getId().equals(member.getId())) {
                 notificationService.createNotification(
-                    newDiscussionComment.getId(),
+                    discussion.getId(),
                     postDiscussionCommentReq.getContent(),
-                    TypeEnum.REPLY_OF_COMMENT,
+                    TypeEnum.DISCUSSION_REPLY_OF_COMMENT,
                     discussion.getMember()
                 );
             }
         } else { //존재하지 않다면 새로운 댓글
-            DiscussionComment newDiscussionComment = discussionCommentRepository.save(
+            discussionCommentRepository.save(
                 new DiscussionComment(
                     postDiscussionCommentReq.getContent(),
                     member,
                     discussion,
                     0)
             );
+
             // 글을 쓴 멤버가 아닌 멤버가 댓글을 달 때만 알림 등록
-            if (!discussion.getId().equals(member.getId())) {
+            if (!discussion.getMember().getId().equals(member.getId())) {
                 notificationService.createNotification(
-                    newDiscussionComment.getId(),
+                    discussion.getId(),
                     postDiscussionCommentReq.getContent(),
                     TypeEnum.DISCUSSION_COMMENT,
                     discussion.getMember()

--- a/src/main/java/com/example/mssaem_backend/domain/notification/NotificationService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/notification/NotificationService.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
+    private static final int lengthLimit = 45;
 
     // 알림 등록 (게시글 댓글, 토론 댓글, hot 게시글, hot 토론, 대댓글)
     @Transactional
@@ -107,8 +108,8 @@ public class NotificationService {
             notificationInfos.add(
                 new NotificationInfo(
                     notification.getId(),
-                    notification.getContent().length() > 45 ?
-                        notification.getContent().substring(0, 45) + "\""
+                    notification.getContent().length() > lengthLimit ?
+                        notification.getContent().substring(0, lengthLimit) + "\""
                         : notification.getContent() + "\"",
                     calculateTime(notification.getCreatedAt(), 4),
                     notification.isState(),

--- a/src/main/java/com/example/mssaem_backend/domain/notification/NotificationService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/notification/NotificationService.java
@@ -26,11 +26,9 @@ public class NotificationService {
     @Transactional
     public void createNotification(Long resourceId, String previewContent,
         TypeEnum type, Member receiver) {
-        previewContent =
-            previewContent.length() >= 20 ? previewContent.substring(0, 20) : previewContent;
         notificationRepository.save(
             new Notification(resourceId,
-                type.getName() + "\n\"" + previewContent + "\"",
+                type.getName() + "\n\"" + previewContent,
                 type,
                 receiver
             )
@@ -41,13 +39,10 @@ public class NotificationService {
     @Transactional
     public void createChatNotification(Long resourceId, String previewContent, TypeEnum type,
         Member sender, Member receiver) {
-        previewContent =
-            previewContent.length() >= 20 ? previewContent.substring(0, 20) : previewContent;
         notificationRepository.save(
             new Notification(
                 resourceId,
-                "\"" + sender.getNickName() + "\"님이 " + type.getName() + "\n\"" + previewContent
-                    + "\"",
+                "\"" + sender.getNickName() + "\"님이 " + type.getName() + "\n\"" + previewContent,
                 type,
                 receiver)
         );
@@ -112,9 +107,12 @@ public class NotificationService {
             notificationInfos.add(
                 new NotificationInfo(
                     notification.getId(),
-                    notification.getContent(),
+                    notification.getContent().length() > 45 ?
+                        notification.getContent().substring(0, 45) + "\""
+                        : notification.getContent() + "\"",
                     calculateTime(notification.getCreatedAt(), 4),
-                    notification.isState()
+                    notification.isState(),
+                    notification.getType()
                 )
             );
         }

--- a/src/main/java/com/example/mssaem_backend/domain/notification/TypeEnum.java
+++ b/src/main/java/com/example/mssaem_backend/domain/notification/TypeEnum.java
@@ -5,9 +5,11 @@ import lombok.Getter;
 public enum TypeEnum {
     BOARD_COMMENT("내 게시물에 댓글이 달렸어요."),
     HOT_BOARD("내 게시글이 HOT한 게시글이 되었어요."),
+
+    BOARD_REPLY_OF_COMMENT("내 댓글에 대댓글이 달렸어요."),
     DISCUSSION_COMMENT("내 토론에 댓글이 달렸어요."),
     HOT_DISCUSSION("내 토론이 HOT한 토론이 되었어요."),
-    REPLY_OF_COMMENT("내 댓글에 대댓글이 달렸어요."),
+    DISCUSSION_REPLY_OF_COMMENT("내 댓글에 대댓글이 달렸어요."),
     HOT_TEACHER("내가 인기 M쌤이 되었어요."),
     CHAT("채팅을 시작했어요.");
 

--- a/src/main/java/com/example/mssaem_backend/domain/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/notification/dto/NotificationResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.mssaem_backend.domain.notification.dto;
 
+import com.example.mssaem_backend.domain.notification.TypeEnum;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,7 +16,7 @@ public class NotificationResponseDto {
         private String content; // 알림 내용
         private String createdAt; // 오늘 알림 : 오전/오후 시간, 오늘 이전 알림 : 0월 0일
         private boolean state; // true : 읽음, false : 안 읽음
-
+        private TypeEnum type; // 알림의 타입
     }
 
 }


### PR DESCRIPTION
## 요약

- 알림 조회시 알림 타입 명시
- 대댓글이 달릴 때 해당 댓글의 게시물이나 토론 id를 resourceId로 저장
- 알림 등록시 문자열 길이 제한 없앰 -> 알림 조회시 길이 제한
- 자신의 글에 댓글 작성시 알림 등록 불가하게 수정

## 상세 내용
### TypeEnum
- 게시물에 대한 대댓글인지, 토론에 대한 대댓글인지 구별할 수 있게 `REPLY_OF_COMMENT`를 `BOARD_REPLY_OF_COMMENT`와 `DISCUSSION_REPLY_OF_COMMENT`로 구분
### NotificationInfo
- TypeEnum 변수 추가 
### BoardCommentService, DiscussionCommentService
- 알림 등록 메소드의 resourceId로 댓글이 달리는 board와 discussion의 id를 넘겨주도록 수정
- 게시물/토론을 작성한 사람과 댓글을 작성한 사람이 일치하는 경우 알림 등록을 못하게 했는데 `board.getId()`와 `member.getId()`를 비교하던 코드를 `board.getMember.getId()`와 비교하게끔 수정
### NotificationService
- 알림을 DB에 저장할 때 프론트 측에서 보여줄 수 있는 글자 길이에 맞춰 저장했는데 추후에 컴포넌트 크기가 바뀔 수 있음을 고려해 저장할 때 전체 다 저장하고, 조회할 때 길이에 맞춰 전송
- 길이 제한 값은 변수로 관리 => `lengthLimit`

## 질문 및 이외 사항

- 

## 이슈 번호

- #135
