### PR TITLE
게시판 별 게시글 개수 조회

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardController.java
@@ -2,6 +2,7 @@ package com.example.mssaem_backend.domain.board;
 
 import com.example.mssaem_backend.domain.board.dto.BoardRequestDto.PatchBoardReq;
 import com.example.mssaem_backend.domain.board.dto.BoardRequestDto.PostBoardReq;
+import com.example.mssaem_backend.domain.board.dto.BoardResponseDto.BoardList;
 import com.example.mssaem_backend.domain.board.dto.BoardResponseDto.BoardSimpleInfo;
 import com.example.mssaem_backend.domain.board.dto.BoardResponseDto.GetBoardRes;
 import com.example.mssaem_backend.domain.board.dto.BoardResponseDto.ThreeHotInfo;
@@ -138,4 +139,9 @@ public class BoardController {
             boardService.findBoardListByKeywordAndMbti(searchReq, strMbti, page, size));
     }
 
+    //게시판 별 게시글 개수 조회
+    @GetMapping("/boards/list")
+    public ResponseEntity<BoardList> findBoardsList() {
+        return ResponseEntity.ok(boardService.getBoardList());
+    }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardRepository.java
@@ -2,6 +2,7 @@ package com.example.mssaem_backend.domain.board;
 
 import com.example.mssaem_backend.domain.mbti.MbtiEnum;
 import com.example.mssaem_backend.domain.member.Member;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -13,13 +14,13 @@ import org.springframework.data.repository.query.Param;
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
     // HOT 게시글 조회
-    Page<Board> findBoardsByLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(Long likeCount,
+    Page<Board> findBoardsByLikeCountGreaterThanEqualAndStateIsTrueOrderByCreatedAtDesc(
+        Long likeCount,
         PageRequest pageRequest);
 
 
     //boardId가 입력되지 않으면 전체 게시글 조회, 입력되면 해당 게시글만 제외하고 전체 조회
     @Query("SELECT b FROM Board b WHERE b.state = true AND (:boardId IS NULL OR b.id <> :boardId) order by b.createdAt desc ")
-
     Page<Board> findAllByStateIsTrueAndIdOrderByCreatedAtDesc(@Param("boardId") Long boardId,
         Pageable pageable);
 
@@ -57,4 +58,9 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     @Query(value = "SELECT SUM(b.likeCount) FROM Board b WHERE b.member = :member AND b.state = true")
     Long sumLikeCountByMember(@Param("member") Member member);
+
+    @Query("select b.mbti, count(b) from Board b where b.state = true group by b.mbti")
+    List<Object[]> countBoardsByMbtiAndStateIsTrue();
+
+    Long countAllByStateIsTrue();
 }

--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
@@ -8,6 +8,7 @@ import com.example.mssaem_backend.domain.badge.BadgeRepository;
 import com.example.mssaem_backend.domain.board.dto.BoardRequestDto.PatchBoardReq;
 import com.example.mssaem_backend.domain.board.dto.BoardRequestDto.PostBoardReq;
 import com.example.mssaem_backend.domain.board.dto.BoardResponseDto.BoardHistory;
+import com.example.mssaem_backend.domain.board.dto.BoardResponseDto.BoardList;
 import com.example.mssaem_backend.domain.board.dto.BoardResponseDto.BoardSimpleInfo;
 import com.example.mssaem_backend.domain.board.dto.BoardResponseDto.GetBoardRes;
 import com.example.mssaem_backend.domain.board.dto.BoardResponseDto.ThreeHotInfo;
@@ -291,6 +292,41 @@ public class BoardService {
             boardCommentRepository.countAllByStateIsTrueAndMember(member),
             boardRepository.sumLikeCountByMember(member)
         );
+    }
+
+    //게시판 별 게시글 개수 조회
+    public BoardList getBoardList() {
+        //BoardList 객체 생성
+        BoardList boardList = new BoardList();
+        //전체 게시글 개수
+        boardList.setBoardCount(boardRepository.countAllByStateIsTrue());
+        //MBTI별 게시글 개수
+        List<Object[]> boardCountList = boardRepository.countBoardsByMbtiAndStateIsTrue();
+        //조회한 데이터를 해당하는 MBTI에 할당
+        for (Object[] row : boardCountList) {
+            MbtiEnum mbti = (MbtiEnum) row[0];
+            Long count = (Long) row[1];
+
+            switch (mbti) {
+                case INFJ -> boardList.setINFJ(count);
+                case INFP -> boardList.setINFP(count);
+                case ISFJ -> boardList.setISFJ(count);
+                case ISFP -> boardList.setISFP(count);
+                case ISTP -> boardList.setISTP(count);
+                case ISTJ -> boardList.setISTJ(count);
+                case INTP -> boardList.setINTP(count);
+                case INTJ -> boardList.setINTJ(count);
+                case ENTP -> boardList.setENTP(count);
+                case ESTJ -> boardList.setESTJ(count);
+                case ESTP -> boardList.setESTP(count);
+                case ENFP -> boardList.setENFP(count);
+                case ESFJ -> boardList.setESFJ(count);
+                case ENTJ -> boardList.setENTJ(count);
+                case ENFJ -> boardList.setENFJ(count);
+                case ESFP -> boardList.setESFP(count);
+            }
+        }
+        return boardList;
     }
 
 }

--- a/src/main/java/com/example/mssaem_backend/domain/board/dto/BoardResponseDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/dto/BoardResponseDto.java
@@ -114,4 +114,96 @@ public class BoardResponseDto {
         private Long boardCommentCount;  // 전체 게시글 댓글 수
         private Long likeAllCount;       // 받은 좋아요의 수
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BoardList {
+
+        private Long INFJ;
+        private Long INFP;
+        private Long ISFJ;
+        private Long ISFP;
+        private Long ISTP;
+        private Long ISTJ;
+        private Long INTP;
+        private Long INTJ;
+        private Long ENTP;
+        private Long ESTJ;
+        private Long ESTP;
+        private Long ENFP;
+        private Long ESFJ;
+        private Long ENTJ;
+        private Long ENFJ;
+        private Long ESFP;
+        private Long boardCount; //전체 게시글 수
+
+        public void setINFJ(Long count) {
+            this.INFJ = count;
+        }
+
+        public void setINFP(Long count) {
+            this.INFP = count;
+        }
+
+        public void setISFJ(Long count) {
+            this.ISFJ = count;
+        }
+
+        public void setISFP(Long count) {
+            this.ISFP = count;
+        }
+
+        public void setISTP(Long count) {
+            this.ISTP = count;
+        }
+
+        public void setISTJ(Long count) {
+            this.ISTJ = count;
+        }
+
+        public void setINTP(Long count) {
+            this.INTP = count;
+        }
+
+        public void setINTJ(Long count) {
+            this.INTJ = count;
+        }
+
+        public void setENTP(Long count) {
+            this.ENTP = count;
+        }
+
+        public void setESTJ(Long count) {
+            this.ESTJ = count;
+        }
+
+        public void setESTP(Long count) {
+            this.ESTP = count;
+        }
+
+        public void setENFP(Long count) {
+            this.ENFP = count;
+        }
+
+        public void setESFJ(Long count) {
+            this.ESFJ = count;
+        }
+
+        public void setENTJ(Long count) {
+            this.ENTJ = count;
+        }
+
+        public void setENFJ(Long count) {
+            this.ENFJ = count;
+        }
+
+        public void setESFP(Long count) {
+            this.ESFP = count;
+        }
+
+        public void setBoardCount(Long count) {
+            this.boardCount = count;
+        }
+    }
 }


### PR DESCRIPTION
## 요약

- 게시판 별 게시글 개수를 조회 하도록 합니다.

## 상세 내용

### BoardRepository
```java
@Query("select b.mbti, count(b) from Board b where b.state = true group by b.mbti")
List<Object[]> countBoardsByMbtiAndStateIsTrue();
```
- 해당 쿼리문을 통해 mbti 유형 별로 게시물 개수를 가져옵니다. List<Object[]> 형태로 반환하여, mbti 값과 해당 mbti 별 게시글 수 가 포함됩니다.

### BoardService
- `getBoardList()` : 위에서 조회한 값을 BoardList 객체로 매핑합니다. for문가 switch 문을 이용하여 구현하였습니다.
- row[0] 에는 MbtiEnum 값, row[1] 에는 각 Mbti별 게시물 수(Long) 값

## 질문 및 이외 사항

- 

## 이슈 번호

- close #184 
