### PR TITLE
기타 신고 사유 Enum 추가 및 에러 수정

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/board/Board.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/Board.java
@@ -91,8 +91,8 @@ public class Board extends BaseTimeEntity {
         this.likeCount--;
     }
 
-    public Integer increaseReport() {
-        return this.report++;
+    public void increaseReport() {
+        this.report++;
     }
 
     public void updateState() {

--- a/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardComment.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardComment.java
@@ -71,8 +71,8 @@ public class BoardComment extends BaseTimeEntity implements Comment {
         this.likeCount--;
     }
 
-    public Integer increaseReport() {
-        return this.report++;
+    public void increaseReport() {
+        this.report++;
     }
 
     public void updateState() {

--- a/src/main/java/com/example/mssaem_backend/domain/discussion/Discussion.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussion/Discussion.java
@@ -67,17 +67,18 @@ public class Discussion extends BaseTimeEntity {
         this.state = false;
     }
 
-    public Integer increaseReport() {
-        return this.report++;
+    public void increaseReport() {
+        this.report++;
     }
 
     public void updateState() {
         this.state = false;
     }
-      
+
     public void increaseCount() {
-        this.participantCount +=1;
+        this.participantCount += 1;
     }
+
     public void increaseCommentCount() {
         this.commentCount++;
     }

--- a/src/main/java/com/example/mssaem_backend/domain/discussioncomment/DiscussionComment.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussioncomment/DiscussionComment.java
@@ -54,8 +54,8 @@ public class DiscussionComment extends BaseTimeEntity implements Comment {
         this.discussion.increaseCommentCount();
     }
 
-    public Integer increaseReport() {
-        return this.report++;
+    public void increaseReport() {
+        this.report++;
     }
 
     public void updateState() {

--- a/src/main/java/com/example/mssaem_backend/domain/member/Member.java
+++ b/src/main/java/com/example/mssaem_backend/domain/member/Member.java
@@ -84,7 +84,7 @@ public class Member extends BaseTimeEntity {
     }
 
     public void modifyMember(String nickName, String introduction, String profileImageUrl,
-                             MbtiEnum mbti, String caseSensitivity, String badgeName) {
+        MbtiEnum mbti, String caseSensitivity, String badgeName) {
         // MBTI 변경 시 프로필 사진이 디폴트라면 프로필 사진도 같이 변경
         if (mbti != null) {
             this.mbti = mbti;
@@ -99,8 +99,8 @@ public class Member extends BaseTimeEntity {
         this.badgeName = badgeName != null ? badgeName : this.badgeName;
     }
 
-    public Integer increaseReport() {
-        return this.report++;
+    public void increaseReport() {
+        this.report++;
     }
 
     public void updateStatus() {

--- a/src/main/java/com/example/mssaem_backend/domain/report/Report.java
+++ b/src/main/java/com/example/mssaem_backend/domain/report/Report.java
@@ -16,6 +16,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.lang.Nullable;
 
 @Getter
 @AllArgsConstructor
@@ -28,21 +29,27 @@ public class Report extends BaseTimeEntity {
     private Long id;
 
     @NotNull
-    private Long resourceId;
+    private Long resourceId; // 신고 대상 id
 
     @NotNull
     @Enumerated(EnumType.STRING)
-    private ReportType reportType;
+    private ReportTarget reportTarget; // 신고 대상 type
 
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private ReportReason reportReason; // 신고 사유
+
+    @Nullable
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
 
     @Builder
-    public Report(Long resourceId, ReportType reportType, String content, Member member) {
+    public Report(Long resourceId, ReportTarget reportTarget, ReportReason reportReason, String content, Member member) {
         this.resourceId = resourceId;
-        this.reportType = reportType;
+        this.reportTarget = reportTarget;
+        this.reportReason = reportReason;
         this.content = content;
         this.member = member;
     }

--- a/src/main/java/com/example/mssaem_backend/domain/report/ReportReason.java
+++ b/src/main/java/com/example/mssaem_backend/domain/report/ReportReason.java
@@ -1,15 +1,19 @@
 package com.example.mssaem_backend.domain.report;
 
-public enum ReportContent {
+import lombok.Getter;
+
+public enum ReportReason {
     PROMOTIONAL_POST("부적절한 홍보 게시글"),
     LEWDNESS("음란성 또는 청소년에게 부적합한 내용"),
     HATRED("증오 또는 악의적인 콘텐츠"),
     TORMENT("괴롭힘 또는 폭력"),
-    INFRINGEMENT("권리 침해");
+    INFRINGEMENT("권리 침해"),
+    ETC("기타");
 
+    @Getter
     private final String name;
 
-    ReportContent(String name) {
+    ReportReason(String name) {
         this.name = name;
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/report/ReportRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/report/ReportRepository.java
@@ -6,8 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
 
-    Report findTopByResourceIdAndReportTypeAndMemberOrderByIdDesc(Long resourceId,
-        ReportType reportType, Member member);
+    Report findTopByResourceIdAndReportTargetAndMemberOrderByIdDesc(Long resourceId,
+        ReportTarget reportTarget, Member member);
 
-    List<Report> findByResourceIdAndReportType(Long resourceId, ReportType reportType);
+    List<Report> findByResourceIdAndReportTarget(Long resourceId, ReportTarget reportTarget);
 }

--- a/src/main/java/com/example/mssaem_backend/domain/report/ReportService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/report/ReportService.java
@@ -45,12 +45,15 @@ public class ReportService {
     private final WorryBoardRepository worryBoardRepository;
     private final MemberRepository memberRepository;
 
-    private static final int reportStandard = 10;
+    private static final Integer REPORT_STANDARD = 10;
+    private static final int REASON_SIZE = 6;
 
     @Transactional
     public String report(Member member, ReportReq reportReq) throws MessagingException {
-        Report prevReport = reportRepository.findTopByResourceIdAndReportTypeAndMemberOrderByIdDesc(
-            reportReq.getResourceId(), reportReq.getReportType(), member);
+        Report prevReport = reportRepository.findTopByResourceIdAndReportTargetAndMemberOrderByIdDesc(
+            reportReq.getResourceId(),
+            reportReq.getReportTarget(),
+            member);
 
         //  신고 테이블에 이미 같은 신고가 있고, 일주일 이내인 경우 신고 못함
         if (prevReport != null && LocalDateTime.now().minusWeeks(1)
@@ -58,16 +61,24 @@ public class ReportService {
             throw new BaseException(ReportError.DUPLICATE_REPORT);
         }
 
-        reportRepository.save(Report.builder().resourceId(reportReq.getResourceId())
-            .reportType(reportReq.getReportType()).content(reportReq.getContent()).member(member)
-            .build());
+        reportRepository.save(
+            Report.builder()
+                .resourceId(reportReq.getResourceId())
+                .reportTarget(reportReq.getReportTarget())
+                .reportReason(reportReq.getReportReason())
+                .content(reportReq.getContent())
+                .member(member)
+                .build()
+        );
 
         // 각 타입별로 신고 대상의 report 수를 +1해주고, 누적 신고 수가 reportStandard인 경우 state를 false로 처리후 안내 메일 전송
-        switch (reportReq.getReportType()) {
+        switch (reportReq.getReportTarget()) {
             case BOARD -> {
                 Board board = boardRepository.findByIdAndStateIsTrue(reportReq.getResourceId())
                     .orElseThrow(() -> new BaseException(BoardErrorCode.EMPTY_BOARD));
-                if (board.increaseReport() >= reportStandard) {
+
+                board.increaseReport();
+                if (board.getReport().equals(REPORT_STANDARD)) {
                     board.updateState();
                     sendReportEmail(board.getMember().getEmail(), reportReq);
                 }
@@ -76,7 +87,9 @@ public class ReportService {
                 Discussion discussion = discussionRepository.findByIdAndStateIsTrue(
                         reportReq.getResourceId())
                     .orElseThrow(() -> new BaseException(DiscussionErrorCode.EMPTY_DISCUSSION));
-                if (discussion.increaseReport() >= reportStandard) {
+
+                discussion.increaseReport();
+                if (discussion.getReport().equals(REPORT_STANDARD)) {
                     discussion.updateState();
                     sendReportEmail(discussion.getMember().getEmail(), reportReq);
                 }
@@ -85,7 +98,9 @@ public class ReportService {
                 WorryBoard worryBoard = worryBoardRepository.findByIdAndStateIsTrue(
                         reportReq.getResourceId())
                     .orElseThrow(() -> new BaseException(WorryBoardErrorCode.EMPTY_WORRY_BOARD));
-                if (worryBoard.increaseReport() >= reportStandard) {
+
+                worryBoard.increaseReport();
+                if (worryBoard.getReport().equals(REPORT_STANDARD)) {
                     worryBoard.updateState();
                     sendReportEmail(worryBoard.getMember().getEmail(), reportReq);
                 }
@@ -94,7 +109,9 @@ public class ReportService {
                 BoardComment boardComment = boardCommentRepository.findByIdAndStateIsTrue(
                     reportReq.getResourceId()).orElseThrow(
                     () -> new BaseException(BoardCommentErrorCode.EMPTY_BOARD_COMMENT));
-                if (boardComment.increaseReport() >= reportStandard) {
+
+                boardComment.increaseReport();
+                if (boardComment.getReport().equals(REPORT_STANDARD)) {
                     boardComment.updateState();
                     sendReportEmail(boardComment.getMember().getEmail(), reportReq);
                 }
@@ -103,7 +120,9 @@ public class ReportService {
                 DiscussionComment discussionComment = discussionCommentRepository.findByIdAndStateIsTrue(
                     reportReq.getResourceId()).orElseThrow(
                     () -> new BaseException(DiscussionCommentErrorCode.EMPTY_DISCUSSION_COMMENT));
-                if (discussionComment.increaseReport() >= reportStandard) {
+
+                discussionComment.increaseReport();
+                if (discussionComment.getReport().equals(REPORT_STANDARD)) {
                     discussionComment.updateState();
                     sendReportEmail(discussionComment.getMember().getEmail(), reportReq);
                 }
@@ -112,7 +131,9 @@ public class ReportService {
                 Member targetMember = memberRepository.findByIdAndStatusIsTrue(
                         reportReq.getResourceId())
                     .orElseThrow(() -> new BaseException(MemberErrorCode.EMPTY_MEMBER));
-                if (targetMember.increaseReport() >= reportStandard) {
+
+                targetMember.increaseReport();
+                if (targetMember.getReport().equals(REPORT_STANDARD)) {
                     targetMember.updateStatus();
                     sendReportEmail(targetMember.getEmail(), reportReq);
                 }
@@ -130,42 +151,47 @@ public class ReportService {
         // 메일 제목 지정
         mail.setSubject("[도와줘요, M쌤] 회원님의 신고 누적으로 인한 임시 정지/삭제에 관해 안내드립니다.", "utf-8");
         // 메일 내용 지정
-        mail.setText(createReportEmailContent(reportReq.getReportType(), count), "utf-8", "html");
+        mail.setText(createReportEmailContent(reportReq.getReportTarget(), count), "utf-8", "html");
 
         // 파라미터로 받은 email을 전송할 email 주소로 설정
-        mail.addRecipient(Message.RecipientType.TO, new InternetAddress(email));
+        mail.addRecipient(Message.RecipientType.TO, new InternetAddress("dbfl0461@gmail.com"));
         // 이메일 전송
         javaMailSender.send(mail);
     }
 
     // 각 신고 내용 별 개수 반환
     private int[] getReportCount(ReportReq reportReq) {
-        int[] count = new int[6];
-        List<Report> reports = reportRepository.findByResourceIdAndReportType(
-            reportReq.getResourceId(), reportReq.getReportType());
+        int[] count = new int[REASON_SIZE];
+        List<Report> reports = reportRepository.findByResourceIdAndReportTarget(
+            reportReq.getResourceId(), reportReq.getReportTarget());
 
+        ReportReason[] reasons = ReportReason.values();
         reports.forEach(report -> {
-            if (report.getContent().equals(ReportContent.PROMOTIONAL_POST.toString())) {
-                count[0]++;
-            } else if (report.getContent().equals(ReportContent.LEWDNESS.toString())) {
-                count[1]++;
-            } else if (report.getContent().equals(ReportContent.HATRED.toString())) {
-                count[2]++;
-            } else if (report.getContent().equals(ReportContent.TORMENT.toString())) {
-                count[3]++;
-            } else if (report.getContent().equals(ReportContent.INFRINGEMENT.toString())) {
-                count[4]++;
-            } else {
-                count[5]++;
+            for (int i = 0; i < count.length; i++) {
+                if (report.getReportReason().equals(reasons[i])) {
+                    count[i]++;
+                    break;
+                }
             }
         });
         return count;
     }
 
     // 이메일 내용에 신고 내역과 타입, 정지 or 삭제 단어 선택
-    private String createReportEmailContent(ReportType reportType, int[] count) {
-        String strType = reportType == ReportType.MEMBER ? "계정" : reportType.getName();
-        String strDelete = reportType == ReportType.MEMBER ? "정지" : "삭제";
+    private String createReportEmailContent(ReportTarget reportTarget, int[] count) {
+        String reportTargetName =
+            reportTarget == ReportTarget.MEMBER ? "계정" : reportTarget.getName();
+        String processType = reportTarget == ReportTarget.MEMBER ? "정지" : "삭제";
+        String reportHistory = "";
+        ReportReason[] reasons = ReportReason.values();
+        for (int i = 0; i < count.length; i++) {
+            reportHistory +=
+                "<p style =\"line-height: 140%;\"><span\n style=\"font-size: 14px; line-height: 19.6px;\">"
+                    + reasons[i].getName()
+                    + " "
+                    + count[i]
+                    + "회</span>\n </p>\n";
+        }
 
         return "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional //EN\"\n"
             + "    \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n"
@@ -399,34 +425,14 @@ public class ReportService {
             + "                          <p style=\"line-height: 140%;\"> </p>\n"
             + "                          <p style=\"line-height: 140%;\"><span\n"
             + "                              style=\"font-size: 16px; line-height: 22.4px;\">회원님의 "
-            + strType + "이 누적 신고 10회 이상으로 </span><span\n"
+            + reportTargetName + "이 누적 신고 10회 이상으로 </span><span\n"
             + "                              style=\"font-size: 16px; line-height: 22.4px;\">임시 "
-            + strDelete + "되었음을 알려드립니다.</span>\n"
+            + processType + "되었음을 알려드립니다.</span>\n"
             + "                          </p>\n"
             + "                          <p style=\"line-height: 140%;\"> </p>\n"
             + "                          <p style=\"line-height: 140%;\"><span\n"
             + "                              style=\"font-size: 16px; line-height: 22.4px;\">신고 내역</span></p>\n"
-            + "                          <p style=\"line-height: 140%;\"><span\n"
-            + "                              style=\"font-size: 14px; line-height: 19.6px;\">부적절한 홍보 게시글 "
-            + count[0] + "회</span>\n"
-            + "                          </p>\n"
-            + "                          <p style=\"line-height: 140%;\"><span\n"
-            + "                              style=\"font-size: 14px; line-height: 19.6px;\">음란성 또는 청소년에게 부적합한 내용 "
-            + count[1] + "회</span>\n"
-            + "                          </p>\n"
-            + "                          <p style=\"line-height: 140%;\"><span\n"
-            + "                              style=\"font-size: 14px; line-height: 19.6px;\">증오 또는 악의적인 콘텐츠 "
-            + count[2] + "회</span>\n"
-            + "                          </p>\n"
-            + "                          <p style=\"line-height: 140%;\"><span\n"
-            + "                              style=\"font-size: 14px; line-height: 19.6px;\">괴롭힘 또는 폭력 "
-            + count[3] + "회</span></p>\n"
-            + "                          <p style=\"line-height: 140%;\"><span\n"
-            + "                              style=\"font-size: 14px; line-height: 19.6px;\">권리 침해 "
-            + count[4] + "회</span></p>\n"
-            + "                          <p style=\"line-height: 140%;\"><span\n"
-            + "                              style=\"font-size: 14px; line-height: 19.6px;\">기타 "
-            + count[5] + "회</span></p>\n"
+            + reportHistory
             + "                          <p style=\"line-height: 140%;\"> </p>\n"
             + "                          <p style=\"line-height: 140%;\"><span\n"
             + "                              style=\"font-size: 16px; line-height: 22.4px;\">문의사항은 도와줘요 M쌤의 이메일을 통해 연락 바랍니다.</span>\n"

--- a/src/main/java/com/example/mssaem_backend/domain/report/ReportService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/report/ReportService.java
@@ -154,7 +154,7 @@ public class ReportService {
         mail.setText(createReportEmailContent(reportReq.getReportTarget(), count), "utf-8", "html");
 
         // 파라미터로 받은 email을 전송할 email 주소로 설정
-        mail.addRecipient(Message.RecipientType.TO, new InternetAddress("dbfl0461@gmail.com"));
+        mail.addRecipient(Message.RecipientType.TO, new InternetAddress(email));
         // 이메일 전송
         javaMailSender.send(mail);
     }

--- a/src/main/java/com/example/mssaem_backend/domain/report/ReportTarget.java
+++ b/src/main/java/com/example/mssaem_backend/domain/report/ReportTarget.java
@@ -2,7 +2,7 @@ package com.example.mssaem_backend.domain.report;
 
 import lombok.Getter;
 
-public enum ReportType {
+public enum ReportTarget {
     BOARD("게시물"),
     DISCUSSION("토론글"),
     WORRY("고민글"),
@@ -13,7 +13,7 @@ public enum ReportType {
     @Getter
     private final String name;
 
-    ReportType(String name) {
+    ReportTarget(String name) {
         this.name = name;
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/report/dto/ReportRequestDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/report/dto/ReportRequestDto.java
@@ -1,6 +1,7 @@
 package com.example.mssaem_backend.domain.report.dto;
 
-import com.example.mssaem_backend.domain.report.ReportType;
+import com.example.mssaem_backend.domain.report.ReportReason;
+import com.example.mssaem_backend.domain.report.ReportTarget;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,7 +14,8 @@ public class ReportRequestDto {
     public static class ReportReq {
 
         Long resourceId; // 신고 대상 id
-        ReportType reportType; // 신고 대상 타입
-        String content; // 신고 사유
+        ReportTarget reportTarget; // 신고 대상 타입
+        ReportReason reportReason; // 신고 사유
+        String content; // 기타 내용
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoard.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoard.java
@@ -88,8 +88,8 @@ public class WorryBoard extends BaseTimeEntity {
         this.state = false;
     }
 
-    public Integer increaseReport() {
-        return this.report++;
+    public void increaseReport() {
+        this.report++;
     }
 
     public void updateState() {


### PR DESCRIPTION
## 요약

- 신고 사유가 기타일 경우 ReportReason 값으로 ETC 추가
- 신고 내역을 가져오는 메소드 유지보수에 용이하게 수정
- 이메일 내용 에러 해결
- 이메일 보내는 누적 신고 횟수 기준 관련 에러 해결

## 상세 내용
### ReportReason
- 신고 사유를 의미하는 Enum 클래스 이름을 `ReportContent` -> `ReportReason`으로 변경
- 신고 사유로 기타인 `ETC`값 추가
### ReportTarget
- 신고 대상을 의미하는 Enum 클래스 이름을 `ReportType` -> `ReportTarget`으로 변경
### ReportService
- `REASON_SIZE` : 신고 사유의 개수를 상수로 관리
- `REPORT_STANDARD` : 이메일을 전송할 누적 신고수 기준을 상수로 관리
- 신고 내역을 메일로 보내주기 위해 각 사유별 신고 횟수를 저장하는 count 배열을 반복문을 통해 계산
- count 배열과 반복문을 이용해 메일 내용에 들어갈 신고 내역 html 코드를 생성 -> `reportHistory`

- 원래는 각 신고 대상별로 `increaseReport()`라는 메소드를 통해 report수를 +1해주고 그 값을 반환해 `REPORT_STANDARD`와 비교했는데 여기서 문제가 발생해 `increaseReport()`와 비교하는 연산을 분리 
    - 왜 문제가 일어나는지 모르겠음,,,,
## 질문 및 이외 사항

- 

## 이슈 번호

- #110
