### PR TITLE
채팅방 생성 및 채팅방 모두 조회 결과 변경

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/chatmessage/ChatMessageRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/chatmessage/ChatMessageRepository.java
@@ -8,8 +8,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
-  @Query("select chm from ChatMessage chm where chm.chatRoom = :chatRoom order by chm.createdAt desc limit 1")
-  ChatMessage selectByChatRoom(@Param("chatRoom") ChatRoom chatRoom);
+  @Query("select chm from ChatMessage chm where chm.chatRoom.id in (:chatRoomIds) order by chm.createdAt desc limit 1")
+  List<ChatMessage> selectByChatRoom(@Param("chatRoomIds") List<Long> chatRoomIds);
 
   @Modifying
   void deleteAllByChatRoom(ChatRoom chatRoom);

--- a/src/main/java/com/example/mssaem_backend/domain/chatparticipate/dto/ChatParticipateResponseDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/chatparticipate/dto/ChatParticipateResponseDto.java
@@ -3,6 +3,7 @@ package com.example.mssaem_backend.domain.chatparticipate.dto;
 import com.example.mssaem_backend.domain.chatmessage.ChatMessage;
 import com.example.mssaem_backend.domain.chatparticipate.ChatParticipate;
 import com.example.mssaem_backend.domain.member.dto.MemberResponseDto.MemberSimpleInfo;
+import com.example.mssaem_backend.domain.worryboard.WorryBoard;
 import com.example.mssaem_backend.global.common.Time;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -19,13 +20,19 @@ public class ChatParticipateResponseDto {
     private boolean state;
     private String lastMessage;
     private String lastSendAt;
+    private String chatRoomTitle;
+    private String memberMbti;
+    private String targetMbti;
     private MemberSimpleInfo memberSimpleInfo;
 
-    public ChatParticipateRes(ChatParticipate chatParticipate, MemberSimpleInfo memberSimpleInfo, ChatMessage message) {
+    public ChatParticipateRes(ChatParticipate chatParticipate, MemberSimpleInfo memberSimpleInfo, ChatMessage message, WorryBoard worryBoard) {
       this.chatRoomId = chatParticipate.getChatRoom().getId();
       this.state = chatParticipate.getChatRoom().isState();
       this.lastMessage = message == null ? "" : message.getMessage();
       this.lastSendAt = message == null ? "" : Time.calculateTime(message.getCreatedAt(), 3);
+      this.chatRoomTitle = chatParticipate.getChatRoom().getTitle();
+      this.memberMbti = chatParticipate.getMember().getDetailMbti();
+      this.targetMbti = worryBoard.getTargetMbti().toString();
       this.memberSimpleInfo = memberSimpleInfo;
     }
 

--- a/src/main/java/com/example/mssaem_backend/domain/chatparticipate/dto/ChatParticipateResponseDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/chatparticipate/dto/ChatParticipateResponseDto.java
@@ -16,7 +16,6 @@ public class ChatParticipateResponseDto {
   public static class ChatParticipateRes {
 
     private Long chatRoomId;
-    private String chatRoomTitle;
     private boolean state;
     private String lastMessage;
     private String lastSendAt;
@@ -24,7 +23,6 @@ public class ChatParticipateResponseDto {
 
     public ChatParticipateRes(ChatParticipate chatParticipate, MemberSimpleInfo memberSimpleInfo, ChatMessage message) {
       this.chatRoomId = chatParticipate.getChatRoom().getId();
-      this.chatRoomTitle = chatParticipate.getChatRoom().getTitle();
       this.state = chatParticipate.getChatRoom().isState();
       this.lastMessage = message == null ? "" : message.getMessage();
       this.lastSendAt = message == null ? "" : Time.calculateTime(message.getCreatedAt(), 3);

--- a/src/main/java/com/example/mssaem_backend/domain/chatroom/ChatRoomController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/chatroom/ChatRoomController.java
@@ -1,7 +1,7 @@
 package com.example.mssaem_backend.domain.chatroom;
 
 import com.example.mssaem_backend.domain.chatroom.dto.ChatRoomRequestDto.ChatInfo;
-import com.example.mssaem_backend.domain.chatroom.dto.ChatRoomRequestDto.ChatRoomInfo;
+import com.example.mssaem_backend.domain.chatroom.dto.ChatRoomResponseDto.ChatRoomRes;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -17,38 +16,38 @@ import org.springframework.web.bind.annotation.RestController;
 
 public class ChatRoomController {
 
-  private final ChatRoomService chatRoomService;
+    private final ChatRoomService chatRoomService;
 
-  /**
-   * 채팅방 개설
-   */
-  @PostMapping("member/chat/rooms")
-  public ResponseEntity<String> createRoom(@RequestBody ChatRoomInfo chatRoomInfo) {
-    return ResponseEntity.ok(chatRoomService.createRoom(chatRoomInfo));
-  }
+    /**
+     * 채팅방 개설
+     */
+    @PostMapping("member/chat/rooms/{worryBoardId}")
+    public ResponseEntity<ChatRoomRes> createRoom(@PathVariable("worryBoardId") Long worryBoardId) {
+        return ResponseEntity.ok(chatRoomService.createRoom(worryBoardId));
+    }
 
-  /**
-   * Redis에 저장된 채팅방 조회(Test)
-   */
-  @GetMapping("/redis/rooms")
-  public List<ChatRoom> selectChatRoom() {
-    return chatRoomService.selectRedisChatRoom();
-  }
+    /**
+     * Redis에 저장된 채팅방 조회(Test)
+     */
+    @GetMapping("/redis/rooms")
+    public List<ChatRoom> selectChatRoom() {
+        return chatRoomService.selectRedisChatRoom();
+    }
 
-  /**
-   * Redis에 저장한 Enter 조회
-   */
-  @GetMapping("/redis/enter/{sessionId}")
-  public ChatInfo enterChat(@PathVariable("sessionId") String sessionId) {
-    return chatRoomService.chatEnter(sessionId);
-  }
+    /**
+     * Redis에 저장한 Enter 조회
+     */
+    @GetMapping("/redis/enter/{sessionId}")
+    public ChatInfo enterChat(@PathVariable("sessionId") String sessionId) {
+        return chatRoomService.chatEnter(sessionId);
+    }
 
-  /**
-   * 채팅방 삭제
-   */
-  @DeleteMapping("member/chat/rooms/{roomId}")
-  public ResponseEntity<String> deleteChatRoom(@PathVariable("roomId") Long roomId){
-    return ResponseEntity.ok(chatRoomService.deleteChatRoom(roomId));
-  }
+    /**
+     * 채팅방 삭제
+     */
+    @DeleteMapping("member/chat/rooms/{roomId}")
+    public ResponseEntity<String> deleteChatRoom(@PathVariable("roomId") Long roomId) {
+        return ResponseEntity.ok(chatRoomService.deleteChatRoom(roomId));
+    }
 
 }

--- a/src/main/java/com/example/mssaem_backend/domain/chatroom/ChatRoomCustomRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/chatroom/ChatRoomCustomRepository.java
@@ -1,7 +1,11 @@
 package com.example.mssaem_backend.domain.chatroom;
 
+import static com.example.mssaem_backend.global.config.exception.errorCode.WorryBoardErrorCode.EMPTY_WORRY_BOARD;
+
 import com.example.mssaem_backend.domain.chatroom.dto.ChatRoomRequestDto.ChatInfo;
-import com.example.mssaem_backend.domain.chatroom.dto.ChatRoomRequestDto.ChatRoomInfo;
+import com.example.mssaem_backend.domain.worryboard.WorryBoard;
+import com.example.mssaem_backend.domain.worryboard.WorryBoardRepository;
+import com.example.mssaem_backend.global.config.exception.BaseException;
 import jakarta.annotation.Resource;
 import java.io.Serializable;
 import java.util.List;
@@ -13,58 +17,60 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class ChatRoomCustomRepository implements Serializable {
 
-  private static final String CHAT_ROOMS = "CHAT_ROOM";
-  public static final String ENTER_INFO = "ENTER_INFO"; // 채팅룸에 입장한 클라이언트의 sessionId와 채팅룸 id를 맵핑한 정보 저장
+    private static final String CHAT_ROOMS = "CHAT_ROOM";
+    public static final String ENTER_INFO = "ENTER_INFO"; // 채팅룸에 입장한 클라이언트의 sessionId와 채팅룸 id를 맵핑한 정보 저장
 
-  @Resource(name = "redisTemplate")
-  private HashOperations<String, Long, ChatRoom> opsHashChatRoom;
-  // 채팅방의 대화 메시지를 발행하기 위한 redis topic 정보. 서버별로 채팅방에 매치되는 topic정보를 Map에 넣어 roomId로 찾을수 있도록 한다.
-  @Resource(name = "redisTemplate")
-  private HashOperations<String, String, ChatInfo> hashOpsEnterInfo;
+    @Resource(name = "redisTemplate")
+    private HashOperations<String, Long, ChatRoom> opsHashChatRoom;
+    // 채팅방의 대화 메시지를 발행하기 위한 redis topic 정보. 서버별로 채팅방에 매치되는 topic정보를 Map에 넣어 roomId로 찾을수 있도록 한다.
+    @Resource(name = "redisTemplate")
+    private HashOperations<String, String, ChatInfo> hashOpsEnterInfo;
 
-  private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final WorryBoardRepository worryBoardRepository;
 
-  public List<ChatRoom> findAllRoom() {
-    return opsHashChatRoom.values(CHAT_ROOMS);
-  }
+    public List<ChatRoom> findAllRoom() {
+        return opsHashChatRoom.values(CHAT_ROOMS);
+    }
 
-  public ChatRoom findRoomById(Long id) {
-    return opsHashChatRoom.get(CHAT_ROOMS, id);
-  }
+    public ChatRoom findRoomById(Long id) {
+        return opsHashChatRoom.get(CHAT_ROOMS, id);
+    }
 
-  /**
-   * 채팅방 생성 : 서버간 채팅방 공유를 위해 redis hash에 저장한다.
-   */
-  public ChatRoom createChatRoom(ChatRoomInfo chatRoomInfo) {
-    ChatRoom chatRoom = ChatRoom.create(chatRoomInfo.getTitle(), chatRoomInfo.getWorryBoardId());
-    chatRoomRepository.save(chatRoom);
-    opsHashChatRoom.put(CHAT_ROOMS, chatRoom.getId(), chatRoom);
-    return chatRoom;
-  }
+    /**
+     * 채팅방 생성 : 서버간 채팅방 공유를 위해 redis hash에 저장한다.
+     */
+    public ChatRoom createChatRoom(Long worryBoardId) {
+        WorryBoard worryBoard = worryBoardRepository.findById(worryBoardId).orElseThrow(() -> new BaseException(EMPTY_WORRY_BOARD));
+        ChatRoom chatRoom = ChatRoom.create(worryBoard.getTitle(), worryBoardId);
+        chatRoomRepository.save(chatRoom);
+        opsHashChatRoom.put(CHAT_ROOMS, chatRoom.getId(), chatRoom);
+        return chatRoom;
+    }
 
-  // 유저가 입장한 채팅방ID와 유저 세션ID 맵핑 정보 저장
-  public void setUserEnterInfo(String sessionId, ChatInfo chatInfo) {
-    hashOpsEnterInfo.put(ENTER_INFO, sessionId, chatInfo);
-  }
+    // 유저가 입장한 채팅방ID와 유저 세션ID 맵핑 정보 저장
+    public void setUserEnterInfo(String sessionId, ChatInfo chatInfo) {
+        hashOpsEnterInfo.put(ENTER_INFO, sessionId, chatInfo);
+    }
 
-  public void setRoomEnterInfo(String sessionId, Long roomId) {
-    ChatInfo chatInfo = hashOpsEnterInfo.get(ENTER_INFO, sessionId);
-    chatInfo.setChatRoomId(roomId);
-    hashOpsEnterInfo.put(ENTER_INFO, sessionId, chatInfo);
-  }
+    public void setRoomEnterInfo(String sessionId, Long roomId) {
+        ChatInfo chatInfo = hashOpsEnterInfo.get(ENTER_INFO, sessionId);
+        chatInfo.setChatRoomId(roomId);
+        hashOpsEnterInfo.put(ENTER_INFO, sessionId, chatInfo);
+    }
 
-  // 유저 세션으로 입장해 있는 채팅방 ID 조회
-  public ChatInfo getUserEnterRoomId(String sessionId) {
-    return hashOpsEnterInfo.get(ENTER_INFO, sessionId);
-  }
+    // 유저 세션으로 입장해 있는 채팅방 ID 조회
+    public ChatInfo getUserEnterRoomId(String sessionId) {
+        return hashOpsEnterInfo.get(ENTER_INFO, sessionId);
+    }
 
-  // 유저 세션정보와 맵핑된 채팅방ID 삭제
-  public void removeUserEnterInfo(String sessionId) {
-    hashOpsEnterInfo.delete(ENTER_INFO, sessionId);
-  }
+    // 유저 세션정보와 맵핑된 채팅방ID 삭제
+    public void removeUserEnterInfo(String sessionId) {
+        hashOpsEnterInfo.delete(ENTER_INFO, sessionId);
+    }
 
-  public void removeChatRoomInfo(Long roomId){
-    opsHashChatRoom.delete(CHAT_ROOMS, roomId);
-  }
+    public void removeChatRoomInfo(Long roomId) {
+        opsHashChatRoom.delete(CHAT_ROOMS, roomId);
+    }
 
 }

--- a/src/main/java/com/example/mssaem_backend/domain/chatroom/ChatRoomRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/chatroom/ChatRoomRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
-    @Query("select wb from WorryBoard wb join ChatRoom cr on cr.worryBoardId = wb.id where cr.id in (:chatRoomIds)")
+    @Query("select wb from ChatRoom cr join WorryBoard wb on cr.worryBoardId = wb.id where cr.id in (:chatRoomIds)")
     List<WorryBoard> findWorryBoardAllByChatRoom(@Param("chatRoomIds") List<Long> chatRoomIds);
 }

--- a/src/main/java/com/example/mssaem_backend/domain/chatroom/ChatRoomRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/chatroom/ChatRoomRepository.java
@@ -1,7 +1,12 @@
 package com.example.mssaem_backend.domain.chatroom;
 
+import com.example.mssaem_backend.domain.worryboard.WorryBoard;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
-
+    @Query("select wb from WorryBoard wb join ChatRoom cr on cr.worryBoardId = wb.id where cr.id in (:chatRoomIds)")
+    List<WorryBoard> findWorryBoardAllByChatRoom(@Param("chatRoomIds") List<Long> chatRoomIds);
 }

--- a/src/main/java/com/example/mssaem_backend/domain/chatroom/ChatRoomService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/chatroom/ChatRoomService.java
@@ -2,7 +2,7 @@ package com.example.mssaem_backend.domain.chatroom;
 
 import com.example.mssaem_backend.domain.chatmessage.ChatMessageService;
 import com.example.mssaem_backend.domain.chatroom.dto.ChatRoomRequestDto.ChatInfo;
-import com.example.mssaem_backend.domain.chatroom.dto.ChatRoomRequestDto.ChatRoomInfo;
+import com.example.mssaem_backend.domain.chatroom.dto.ChatRoomResponseDto.ChatRoomRes;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,9 +16,9 @@ public class ChatRoomService {
   private final ChatRoomRepository chatRoomRepository;
   private final ChatMessageService chatMessageService;
 
-  public String createRoom(ChatRoomInfo chatRoomInfo) {
-    chatRoomCustomRepository.createChatRoom(chatRoomInfo);
-    return "채팅방 생성 완료";
+  public ChatRoomRes createRoom(Long worryBoardId) {
+    ChatRoom chatRoom = chatRoomCustomRepository.createChatRoom(worryBoardId);
+    return new ChatRoomRes(chatRoom);
   }
 
   /**

--- a/src/main/java/com/example/mssaem_backend/domain/chatroom/dto/ChatRoomRequestDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/chatroom/dto/ChatRoomRequestDto.java
@@ -8,21 +8,20 @@ import lombok.NoArgsConstructor;
 
 public class ChatRoomRequestDto {
 
-  @Getter
-  @NoArgsConstructor
-  @AllArgsConstructor
-  public static class ChatRoomInfo {
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChatRoomInfo {
 
-    private String title;
-    private Long worryBoardId;
-  }
+        private Long worryBoardId;
+    }
 
-  @Data
-  @NoArgsConstructor
-  @AllArgsConstructor
-  public static class ChatInfo implements Serializable {
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChatInfo implements Serializable {
 
-    private Long chatRoomId;
-    private String sender;
-  }
+        private Long chatRoomId;
+        private String sender;
+    }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/chatroom/dto/ChatRoomResponseDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/chatroom/dto/ChatRoomResponseDto.java
@@ -1,7 +1,6 @@
 package com.example.mssaem_backend.domain.chatroom.dto;
 
 import com.example.mssaem_backend.domain.chatroom.ChatRoom;
-import com.example.mssaem_backend.domain.member.Member;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,13 +11,9 @@ public class ChatRoomResponseDto {
   @NoArgsConstructor
   @AllArgsConstructor
   public static class ChatRoomRes {
-    private String chatRoomTitle;
-    private boolean state;
-    private String memberNickName;
-    public ChatRoomRes(ChatRoom chatRoom, Member member) {
-        this.chatRoomTitle = chatRoom.getTitle();
-        this.state = chatRoom.isState();
-        this.memberNickName = member.getNickName();
+    private Long chatRoomId;
+    public ChatRoomRes(ChatRoom chatRoom) {
+        this.chatRoomId = chatRoom.getId();
     }
   }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardController.java
@@ -6,6 +6,7 @@ import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.Pat
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.PatchWorrySolvedReq;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.PostWorryReq;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardResponseDto.GetWorriesRes;
+import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardResponseDto.GetWorryBoardId;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardResponseDto.GetWorryRes;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardResponseDto.PatchWorrySolvedRes;
 import com.example.mssaem_backend.global.common.dto.PageResponseDto;
@@ -100,7 +101,7 @@ public class WorryBoardController {
 
     //고민글 생성
     @PostMapping("/member/worry-board")
-    public ResponseEntity<String> createWorryBoard(@CurrentMember Member currentMember,
+    public ResponseEntity<GetWorryBoardId> createWorryBoard(@CurrentMember Member currentMember,
         @RequestPart(value = "postWorryReq") PostWorryReq postWorryReq,
         @RequestPart(value = "image", required = false) List<String> imgUrls) {
         return ResponseEntity.ok(

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
@@ -15,6 +15,7 @@ import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.Pat
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.PatchWorrySolvedReq;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardRequestDto.PostWorryReq;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardResponseDto.GetWorriesRes;
+import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardResponseDto.GetWorryBoardId;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardResponseDto.GetWorryRes;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardResponseDto.PatchWorrySolvedRes;
 import com.example.mssaem_backend.domain.worryboard.dto.WorryBoardResponseDto.WorryBoardHistory;
@@ -170,7 +171,7 @@ public class WorryBoardService {
 
     //고민글 생성
     @Transactional
-    public String createWorryBoard(Member currentMember, PostWorryReq postWorryReq,
+    public GetWorryBoardId createWorryBoard(Member currentMember, PostWorryReq postWorryReq,
         List<String> imgUrls) {
         //고민글 내용 저장
         WorryBoard worryBoard = WorryBoard.builder()
@@ -186,8 +187,8 @@ public class WorryBoardService {
             String thumbnail = worryBoardImageService.uploadWorryBoardImageUrl(worryBoard, imgUrls);
             worryBoard.changeThumbnail(thumbnail);
         }
-        worryBoardRepository.save(worryBoard);
-        return "고민글 생성 완료";
+        WorryBoard worryboard = worryBoardRepository.save(worryBoard);
+        return new GetWorryBoardId(worryboard.getId());
     }
 
     //고민글 수정

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/dto/WorryBoardResponseDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/dto/WorryBoardResponseDto.java
@@ -118,5 +118,12 @@ public class WorryBoardResponseDto {
         }
     }
 
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    public static class GetWorryBoardId {
+        private Long worryBoardId;
+    }
+
 }
 


### PR DESCRIPTION
## 요약
- 채팅방이 생성하면 채팅방 ID가 출력됩니다.
- 채팅방을 모두 조회할 때, 고민 게시글 제목, memberMbti, targetMbti를 추가했습니다.
- 고민 게시글을 생성할 때 고민글 ID가 출력됩니다.

## 상세 내용
-  채팅방을 모두 조회할 때, 채팅방에 고민 게시글에 대한 정보를 추가했습니다.
- 이 때, 고민 게시글이 채팅방과 연관이 되어 있지 않아 join을 사용했습니다. 

### 각각 레포지토리
```
@Query("select wb from ChatRoom cr join WorryBoard wb on cr.worryBoardId = wb.id where cr.id in (:chatRoomIds)")
    List<WorryBoard> findWorryBoardAllByChatRoom(@Param("chatRoomIds") List<Long> chatRoomIds);

@Query("select chm from ChatMessage chm where chm.chatRoom.id in (:chatRoomIds) order by chm.createdAt desc limit 1")
  List<ChatMessage> selectByChatRoom(@Param("chatRoomIds") List<Long> chatRoomIds);

 @Query("select cp from ChatParticipate cp join fetch cp.chatRoom join fetch cp.member where cp.member <> :member and cp.chatRoom.id in (:roomIds)")
    List<ChatParticipate> findAllParticipateRoom(@Param("member") Member member, @Param("roomIds") List<Long> roomIds);

```
모든 것을 한방 쿼리로 조회하기 위해 in을 사용했습니다. 각각 List로 가져온 뒤 하나의 DTO로 합쳐주는 형식으로 했습니다. 
stream을 안쓰고 이렇게 한 이유는 stream으로 할 경우 반목문을 돌면서 하나의 채팅방 마다 worryboard와 각각의 최종 채팅을 조회 해야 하기 때문입니다. 이럴 경우 쿼리가 채팅방 갯수만큼 나갑니다!!!!

## 이슈 번호
- close #201 
