### PR TITLE
채팅방 제목 수정 및 각 채팅방 최근 채팅 출력

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/chatmessage/ChatMessageRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/chatmessage/ChatMessageRepository.java
@@ -8,7 +8,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
-  @Query("select chm from ChatMessage chm where chm.chatRoom.id in (:chatRoomIds) order by chm.createdAt desc limit 1")
+  @Query("select chm from ChatMessage chm where (chm.chatRoom.id, chm.createdAt) in "
+      + "(select chm2.chatRoom.id, MAX(chm2.createdAt) from ChatMessage chm2"
+      + " where chm2.chatRoom.id in :chatRoomIds group by chm2.chatRoom.id)")
   List<ChatMessage> selectByChatRoom(@Param("chatRoomIds") List<Long> chatRoomIds);
 
   @Modifying

--- a/src/main/java/com/example/mssaem_backend/domain/chatparticipate/ChatParticipate.java
+++ b/src/main/java/com/example/mssaem_backend/domain/chatparticipate/ChatParticipate.java
@@ -17,21 +17,21 @@ import org.hibernate.annotations.DynamicInsert;
 @Entity
 public class ChatParticipate extends BaseTimeEntity {
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-  private String sessionId;
+    private String sessionId;
 
-  @OneToOne(fetch = FetchType.LAZY)
-  private ChatRoom chatRoom;
+    @OneToOne(fetch = FetchType.LAZY)
+    private ChatRoom chatRoom;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  private Member member;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
 
-  public ChatParticipate(String sessionId, ChatRoom chatRoom, Member member) {
-    this.sessionId = sessionId;
-    this.chatRoom = chatRoom;
-    this.member = member;
-  }
+    public ChatParticipate(String sessionId, ChatRoom chatRoom, Member member) {
+        this.sessionId = sessionId;
+        this.chatRoom = chatRoom;
+        this.member = member;
+    }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/chatparticipate/ChatParticipateController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/chatparticipate/ChatParticipateController.java
@@ -13,14 +13,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class ChatParticipateController {
 
-  private final ChatParticipateService chatParticipateService;
+    private final ChatParticipateService chatParticipateService;
 
-  /**
-   * 현재 로그인 한 member의 채팅방 모두 조회
-   */
-  @GetMapping("/member/chatRooms")
-  public ResponseEntity<List<ChatParticipateRes>> selectChatRooms(@CurrentMember Member member) {
-    return ResponseEntity.ok(chatParticipateService.selectChatRooms(member));
-  }
+    /**
+     * 현재 로그인 한 member의 채팅방 모두 조회
+     */
+    @GetMapping("/member/chatRooms")
+    public ResponseEntity<List<ChatParticipateRes>> selectChatRooms(@CurrentMember Member member) {
+        return ResponseEntity.ok(chatParticipateService.selectChatRooms(member));
+    }
 
 }

--- a/src/main/java/com/example/mssaem_backend/domain/chatparticipate/ChatParticipateRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/chatparticipate/ChatParticipateRepository.java
@@ -13,7 +13,8 @@ public interface ChatParticipateRepository extends JpaRepository<ChatParticipate
     List<Long> findAllByMemberParticipateRoomId(@Param("member") Member member);
 
     @Query("select cp from ChatParticipate cp join fetch cp.chatRoom join fetch cp.member where cp.member <> :member and cp.chatRoom.id in (:roomIds)")
-    List<ChatParticipate> findAllParticipateRoom(@Param("member") Member member, @Param("roomIds") List<Long> roomIds);
+    List<ChatParticipate> findAllParticipateRoom(@Param("member") Member member,
+        @Param("roomIds") List<Long> roomIds);
 
     ChatParticipate findBySessionId(String sessionId);
 

--- a/src/main/java/com/example/mssaem_backend/domain/chatparticipate/ChatParticipateService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/chatparticipate/ChatParticipateService.java
@@ -79,19 +79,16 @@ public class ChatParticipateService {
             participateChatRoomIds);
 
         List<ChatParticipateRes> result = new ArrayList<>();
-        int chatMessagesIdx = 0;
+
         for (int i = 0; i < allParticipateRoom.size(); ++i) {
             ChatParticipate nowChatParticipate = allParticipateRoom.get(i);
             ChatMessage nowChatMessage = null;
             WorryBoard nowWorryBoard = worryBoardAllByChatRoom.get(i);
 
-            if (chatMessagesIdx < chatMessages.size()) {
-                nowChatMessage = chatMessages.get(chatMessagesIdx);
-                if (nowChatMessage.getChatRoom().getId() != nowChatParticipate.getChatRoom()
-                    .getId()) {
-                    nowChatMessage = null;
-                } else {
-                    chatMessagesIdx++;
+            for(ChatMessage chm : chatMessages){
+                if(chm.getChatRoom().getId() == nowChatParticipate.getChatRoom().getId()) {
+                    nowChatMessage = chm;
+                    break;
                 }
             }
 

--- a/src/main/java/com/example/mssaem_backend/domain/chatparticipate/ChatParticipateService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/chatparticipate/ChatParticipateService.java
@@ -85,8 +85,8 @@ public class ChatParticipateService {
             ChatMessage nowChatMessage = null;
             WorryBoard nowWorryBoard = worryBoardAllByChatRoom.get(i);
 
-            for(ChatMessage chm : chatMessages){
-                if(chm.getChatRoom().getId() == nowChatParticipate.getChatRoom().getId()) {
+            for (ChatMessage chm : chatMessages) {
+                if (chm.getChatRoom().getId() == nowChatParticipate.getChatRoom().getId()) {
                     nowChatMessage = chm;
                     break;
                 }

--- a/src/main/java/com/example/mssaem_backend/domain/chatparticipate/dto/ChatParticipateResponseDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/chatparticipate/dto/ChatParticipateResponseDto.java
@@ -11,30 +11,33 @@ import lombok.NoArgsConstructor;
 
 public class ChatParticipateResponseDto {
 
-  @Getter
-  @NoArgsConstructor
-  @AllArgsConstructor
-  public static class ChatParticipateRes {
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChatParticipateRes {
 
-    private Long chatRoomId;
-    private boolean state;
-    private String lastMessage;
-    private String lastSendAt;
-    private String chatRoomTitle;
-    private String memberMbti;
-    private String targetMbti;
-    private MemberSimpleInfo memberSimpleInfo;
+        private Long chatRoomId;
+        private boolean state;
+        private String lastMessage;
+        private String lastSendAt;
+        private String chatRoomTitle;
+        private String memberMbti;
+        private String targetMbti;
+        private MemberSimpleInfo memberSimpleInfo;
+        private Long worryBoardId;
 
-    public ChatParticipateRes(ChatParticipate chatParticipate, MemberSimpleInfo memberSimpleInfo, ChatMessage message, WorryBoard worryBoard) {
-      this.chatRoomId = chatParticipate.getChatRoom().getId();
-      this.state = chatParticipate.getChatRoom().isState();
-      this.lastMessage = message == null ? "" : message.getMessage();
-      this.lastSendAt = message == null ? "" : Time.calculateTime(message.getCreatedAt(), 3);
-      this.chatRoomTitle = worryBoard.getTitle();
-      this.memberMbti = chatParticipate.getMember().getDetailMbti();
-      this.targetMbti = worryBoard.getTargetMbti().toString();
-      this.memberSimpleInfo = memberSimpleInfo;
+        public ChatParticipateRes(ChatParticipate chatParticipate,
+            MemberSimpleInfo memberSimpleInfo, ChatMessage message, WorryBoard worryBoard) {
+            this.chatRoomId = chatParticipate.getChatRoom().getId();
+            this.state = chatParticipate.getChatRoom().isState();
+            this.lastMessage = message == null ? "" : message.getMessage();
+            this.lastSendAt = message == null ? "" : Time.calculateTime(message.getCreatedAt(), 3);
+            this.chatRoomTitle = worryBoard.getTitle();
+            this.memberMbti = chatParticipate.getMember().getDetailMbti();
+            this.targetMbti = worryBoard.getTargetMbti().toString();
+            this.memberSimpleInfo = memberSimpleInfo;
+            this.worryBoardId = worryBoard.getId();
+        }
+
     }
-
-  }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/chatparticipate/dto/ChatParticipateResponseDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/chatparticipate/dto/ChatParticipateResponseDto.java
@@ -30,7 +30,7 @@ public class ChatParticipateResponseDto {
       this.state = chatParticipate.getChatRoom().isState();
       this.lastMessage = message == null ? "" : message.getMessage();
       this.lastSendAt = message == null ? "" : Time.calculateTime(message.getCreatedAt(), 3);
-      this.chatRoomTitle = chatParticipate.getChatRoom().getTitle();
+      this.chatRoomTitle = worryBoard.getTitle();
       this.memberMbti = chatParticipate.getMember().getDetailMbti();
       this.targetMbti = worryBoard.getTargetMbti().toString();
       this.memberSimpleInfo = memberSimpleInfo;

--- a/src/main/java/com/example/mssaem_backend/domain/chatroom/ChatRoom.java
+++ b/src/main/java/com/example/mssaem_backend/domain/chatroom/ChatRoom.java
@@ -34,4 +34,8 @@ public class ChatRoom extends BaseTimeEntity implements Serializable {
         chatRoom.worryBoardId = worryBoardId;
         return chatRoom;
     }
+
+    public void setChatRoomTitle(String title){
+        this.title = title;
+    }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/worryboard/WorryBoardService.java
@@ -5,7 +5,6 @@ import static com.example.mssaem_backend.global.common.CheckWriter.match;
 import static com.example.mssaem_backend.global.common.Time.calculateTime;
 import static com.example.mssaem_backend.global.config.exception.errorCode.ChatRoomErrorCode.EMPTY_CHATROOM;
 
-import com.example.mssaem_backend.domain.badge.BadgeService;
 import com.example.mssaem_backend.domain.chatroom.ChatRoom;
 import com.example.mssaem_backend.domain.chatroom.ChatRoomRepository;
 import com.example.mssaem_backend.domain.evaluation.EvaluationRepository;
@@ -42,7 +41,6 @@ public class WorryBoardService {
     private final WorryBoardRepository worryBoardRepository;
     private final WorryBoardImageService worryBoardImageService;
     private final MemberRepository memberRepository;
-    private final BadgeService badgeService;
     private final EvaluationRepository evaluationRepository;
     private final ChatRoomRepository chatRoomRepository;
 
@@ -208,6 +206,12 @@ public class WorryBoardService {
         WorryBoard worryBoard = worryBoardRepository.findById(id)
             .orElseThrow(() -> new BaseException(WorryBoardErrorCode.EMPTY_WORRY_BOARD));
         match(currentMember, worryBoard.getMember());
+
+        if(!patchWorryReq.getTitle().equals(worryBoard.getTitle())){
+            ChatRoom chatRoom = chatRoomRepository.findByWorryBoardId(
+                worryBoard.getId()).orElseThrow(() -> new BaseException(EMPTY_CHATROOM));
+            chatRoom.setChatRoomTitle(patchWorryReq.getTitle());
+        }
 
         //worryBoard 수정하기
         worryBoard.modifyWorryBoard(


### PR DESCRIPTION
## 요약
- 채팅방 제목 수정 및 각 채팅방 최근 채팅 출력

## 상세 내용
- 고민 게시판에 제목이 수정되면 채팅방 제목이 수정되어야 합니다
- 각 채팅방에 가장 최근 채팅에 대한 정보가 출력되어야 합니다.

```
  @Query("select chm from ChatMessage chm where (chm.chatRoom.id, chm.createdAt) in "
      + "(select chm2.chatRoom.id, MAX(chm2.createdAt) from ChatMessage chm2"
      + " where chm2.chatRoom.id in :chatRoomIds group by chm2.chatRoom.id)")
  List<ChatMessage> selectByChatRoom(@Param("chatRoomIds") List<Long> chatRoomIds);
```
각 채팅방의 최근 메시지를 출력하는 쿼리문 입니다. 
예를 들어 유저 A가 채팅방 1,2,3에 들어가 있다면 채팅방 1,2,3에서 제일 최근 채팅을 출력합니다. 
이때, 한 방에 조회 하기 위해 채팅방 id를 List를 준 뒤 in을 사용했습니다. 또 제일 최근이므로 MAX를 사용했습니다.

## 이슈 번호
- close #212 