### PR TITLE
댓글 조회 오류 수정

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/boardcomment/BoardCommentRepository.java
@@ -18,7 +18,7 @@ public interface BoardCommentRepository extends JpaRepository<BoardComment, Long
 
     Long countAllByStateIsTrueAndMember(@Param("member") Member member);
 
-    @Query(value = "select bc from BoardComment bc join fetch bc.member where bc.board.id = :id", countQuery = "select count(bc) from BoardComment bc")
+    @Query(value = "SELECT bc FROM BoardComment bc JOIN FETCH bc.member WHERE bc.board.id = :id ORDER BY bc.createdAt ASC", countQuery = "SELECT count(bc) FROM BoardComment bc")
     Page<BoardComment> findAllByBoardId(@Param("id") Long id, Pageable pageable);
 
     Optional<BoardComment> findByIdAndStateIsTrue(Long id);

--- a/src/main/java/com/example/mssaem_backend/domain/discussioncomment/DiscussionComment.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussioncomment/DiscussionComment.java
@@ -5,7 +5,12 @@ import com.example.mssaem_backend.domain.discussion.Discussion;
 import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.global.common.BaseTimeEntity;
 import com.example.mssaem_backend.global.common.Comment;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -36,9 +41,6 @@ public class DiscussionComment extends BaseTimeEntity implements Comment {
 
     @ColumnDefault("0")
     private Long parentId; //댓글 : 0, 대 댓글 : 자신의 부모 댓글 id
-
-    @ColumnDefault("0")
-    private Integer orders; //대댓글의 순서
 
     private boolean state = true; //true : 존재, false : 삭제
 

--- a/src/main/java/com/example/mssaem_backend/domain/discussioncomment/DiscussionCommentController.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussioncomment/DiscussionCommentController.java
@@ -28,8 +28,8 @@ public class DiscussionCommentController {
     //토론글 상세 조회시 댓글 조회
     @GetMapping("/discussions/{discussionId}/comments")
     public ResponseEntity<PageResponseDto<List<GetCommentsRes>>> findDiscussionComments(
-        @CurrentMember Member member, @PathVariable Long discussionId, @RequestParam int page,
-        @RequestParam int size) {
+        @CurrentMember Member member, @PathVariable(value = "discussionId") Long discussionId,
+        @RequestParam(value = "page") int page, @RequestParam(value = "size") int size) {
         return ResponseEntity.ok(
             commentService.findCommentsByPostId(member, discussionId, page, size,
                 CommentTypeEnum.DISCUSSION));
@@ -51,7 +51,7 @@ public class DiscussionCommentController {
         @RequestParam(value = "commentId", required = false) Long commentId) {
         return ResponseEntity.ok(
             commentService.createComment(member, discussionId,
-                postCommentReq, commentId, CommentTypeEnum.DISCUSSION, commentId!=null));
+                postCommentReq, commentId, CommentTypeEnum.DISCUSSION, commentId != null));
     }
 
     //댓글 삭제
@@ -60,7 +60,8 @@ public class DiscussionCommentController {
         @PathVariable(value = "discussionId") Long discussionId,
         @PathVariable(value = "commentId") Long commentId) {
         return ResponseEntity.ok(
-            commentService.deleteComment(member, discussionId, commentId, CommentTypeEnum.DISCUSSION));
+            commentService.deleteComment(member, discussionId, commentId,
+                CommentTypeEnum.DISCUSSION));
     }
 
     //특정 멤버별 토론글 댓글 보기

--- a/src/main/java/com/example/mssaem_backend/domain/discussioncomment/DiscussionCommentRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussioncomment/DiscussionCommentRepository.java
@@ -18,7 +18,7 @@ public interface DiscussionCommentRepository extends JpaRepository<DiscussionCom
 
     Optional<DiscussionComment> findByIdAndStateIsTrue(Long id);
 
-    @Query(value = "select dc from DiscussionComment dc join fetch dc.member where dc.discussion.id = :id", countQuery = "select count(dc) from DiscussionComment dc")
+    @Query(value = "SELECT dc FROM DiscussionComment dc JOIN FETCH dc.member WHERE dc.discussion.id = :id ORDER BY dc.createdAt ASC", countQuery = "SELECT count(dc) FROM DiscussionComment dc")
     Page<DiscussionComment> findAllByDiscussionId(@Param("id") Long id, Pageable pageable);
 
     DiscussionComment findByIdAndDiscussionIdAndStateIsTrue(Long commentId, Long discussionId);

--- a/src/main/java/com/example/mssaem_backend/global/common/dto/CommentDto.java
+++ b/src/main/java/com/example/mssaem_backend/global/common/dto/CommentDto.java
@@ -13,6 +13,7 @@ public class CommentDto {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class PostCommentReq {
+
         private String content;
     }
 
@@ -24,19 +25,19 @@ public class CommentDto {
         private Long commentId;
         private String content;
         private Long likeCount;
-        private Integer parentId;
+        private Long parentId;
         private String createdAt;
         private Boolean isLiked; // 댓글 좋아요 눌렀는지 확인
         private Boolean isEditAllowed; //댓글 또는 신고를 위한 내 댓글인지 확인
         private MemberSimpleInfo memberSimpleInfo;
 
         @Builder
-        public GetCommentsRes(Comment comment, MemberSimpleInfo memberSimpleInfo, String createdAt, Boolean isEditAllowed,
-            Boolean isLiked) {
+        public GetCommentsRes(Comment comment, MemberSimpleInfo memberSimpleInfo, String createdAt,
+            Boolean isEditAllowed, Boolean isLiked) {
             this.commentId = comment.getId();
             this.content = comment.getContent();
             this.likeCount = comment.getLikeCount();
-            this.parentId = getParentId();
+            this.parentId = comment.getParentId();
             this.memberSimpleInfo = memberSimpleInfo;
             this.createdAt = createdAt;
             this.isEditAllowed = isEditAllowed;
@@ -53,20 +54,21 @@ public class CommentDto {
         private Long commentId;
         private String content;
         private Long likeCount;
-        private Integer parentId;
+        private Long parentId;
         private String createdAt;
         private Boolean isLiked; // 댓글 좋아요 눌렀는지 확인
         private Boolean isEditAllowed; //삭제 또는 신고를 위한 내 댓글인지 확인
         private MemberSimpleInfo memberSimpleInfo;
 
         @Builder
-        public GetCommentsByMemberRes(Long postId, Comment comment, MemberSimpleInfo memberSimpleInfo, String createdAt, Boolean isEditAllowed,
+        public GetCommentsByMemberRes(Long postId, Comment comment,
+            MemberSimpleInfo memberSimpleInfo, String createdAt, Boolean isEditAllowed,
             Boolean isLiked) {
             this.PostId = postId;
             this.commentId = comment.getId();
             this.content = comment.getContent();
             this.likeCount = comment.getLikeCount();
-            this.parentId = getParentId();
+            this.parentId = comment.getParentId();
             this.memberSimpleInfo = memberSimpleInfo;
             this.createdAt = createdAt;
             this.isEditAllowed = isEditAllowed;


### PR DESCRIPTION
## 요약

- 댓글 조회 시 parentId 값을 받아오지 못해 생기는 오류 수정
- 불필요한 필드 값 삭제

## 상세 내용

- 

## 질문 및 이외 사항

- 

## 이슈 번호

- close #216 
