### PR TITLE
알림 응답 형식 수정

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/chatparticipate/ChatParticipateService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/chatparticipate/ChatParticipateService.java
@@ -9,7 +9,7 @@ import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.domain.member.MemberRepository;
 import com.example.mssaem_backend.domain.member.dto.MemberResponseDto.MemberSimpleInfo;
 import com.example.mssaem_backend.domain.notification.NotificationService;
-import com.example.mssaem_backend.domain.notification.TypeEnum;
+import com.example.mssaem_backend.domain.notification.NotificationType;
 import com.example.mssaem_backend.domain.worryboard.WorryBoard;
 import com.example.mssaem_backend.global.config.exception.BaseException;
 import com.example.mssaem_backend.global.config.exception.errorCode.ChatRoomParticipateErrorCode;
@@ -38,13 +38,11 @@ public class ChatParticipateService {
 
         // 채팅방이 만들어져 있고 해당 채팅방의 두번째 참가자(고민을 올린 사람)일 경우 채팅 시작 알림 전송
         ChatParticipate prevParticipate = chatParticipateRepository.findByChatRoom(chatRoom);
-        System.out.println(prevParticipate + "존재함");
         if (prevParticipate != null) {
-            notificationService.createChatNotification(
+            notificationService.createNotification(
                 chatRoom.getId(),
                 chatRoom.getTitle(),
-                TypeEnum.CHAT,
-                prevParticipate.getMember(),
+                NotificationType.CHAT,
                 member
             );
         }

--- a/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionService.java
@@ -20,7 +20,7 @@ import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.domain.member.MemberRepository;
 import com.example.mssaem_backend.domain.member.dto.MemberResponseDto.MemberSimpleInfo;
 import com.example.mssaem_backend.domain.notification.NotificationService;
-import com.example.mssaem_backend.domain.notification.TypeEnum;
+import com.example.mssaem_backend.domain.notification.NotificationType;
 import com.example.mssaem_backend.global.common.CommentService;
 import com.example.mssaem_backend.global.common.CommentTypeEnum;
 import com.example.mssaem_backend.global.common.Time;
@@ -312,7 +312,7 @@ public class DiscussionService {
                 notificationService.createNotification(
                     discussionId,
                     discussion.getTitle(),
-                    TypeEnum.HOT_DISCUSSION,
+                    NotificationType.HOT_DISCUSSION,
                     discussion.getMember()
                 );
             }

--- a/src/main/java/com/example/mssaem_backend/domain/like/LikeService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/like/LikeService.java
@@ -4,7 +4,7 @@ import com.example.mssaem_backend.domain.board.Board;
 import com.example.mssaem_backend.domain.board.BoardRepository;
 import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.domain.notification.NotificationService;
-import com.example.mssaem_backend.domain.notification.TypeEnum;
+import com.example.mssaem_backend.domain.notification.NotificationType;
 import com.example.mssaem_backend.global.config.exception.BaseException;
 import com.example.mssaem_backend.global.config.exception.errorCode.BoardErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -37,7 +37,7 @@ public class LikeService {
                 notificationService.createNotification(
                     boardId,
                     board.getTitle(),
-                    TypeEnum.HOT_BOARD,
+                    NotificationType.HOT_BOARD,
                     board.getMember()
                 );
             }
@@ -51,7 +51,7 @@ public class LikeService {
                 notificationService.createNotification(
                     boardId,
                     board.getTitle(),
-                    TypeEnum.HOT_BOARD,
+                    NotificationType.HOT_BOARD,
                     board.getMember()
                 );
             }

--- a/src/main/java/com/example/mssaem_backend/domain/notification/Notification.java
+++ b/src/main/java/com/example/mssaem_backend/domain/notification/Notification.java
@@ -38,15 +38,16 @@ public class Notification extends BaseTimeEntity {
 
     @NotNull
     @Enumerated(EnumType.STRING)
-    private TypeEnum type;
+    private NotificationType notificationType;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member; // 알림을 받을 멤버
 
-    public Notification(Long resourceId, String content, TypeEnum type, Member member) {
+    public Notification(Long resourceId, String content, NotificationType notificationType,
+        Member member) {
         this.resourceId = resourceId;
         this.content = content;
-        this.type = type;
+        this.notificationType = notificationType;
         this.member = member;
     }
 

--- a/src/main/java/com/example/mssaem_backend/domain/notification/NotificationService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/notification/NotificationService.java
@@ -21,31 +21,18 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
-    private static final int lengthLimit = 45;
+    private static final int CONTENT_LENGTH_LIMIT = 25;
 
     // 알림 등록 (게시글 댓글, 토론 댓글, hot 게시글, hot 토론, 대댓글)
     @Transactional
     public void createNotification(Long resourceId, String previewContent,
-        TypeEnum type, Member receiver) {
+        NotificationType notificationType, Member receiver) {
         notificationRepository.save(
             new Notification(resourceId,
-                type.getName() + "\n\"" + previewContent,
-                type,
+                previewContent,
+                notificationType,
                 receiver
             )
-        );
-    }
-
-    // 채팅 시작시 알림 등록
-    @Transactional
-    public void createChatNotification(Long resourceId, String previewContent, TypeEnum type,
-        Member sender, Member receiver) {
-        notificationRepository.save(
-            new Notification(
-                resourceId,
-                "\"" + sender.getNickName() + "\"님이 " + type.getName() + "\n\"" + previewContent,
-                type,
-                receiver)
         );
     }
 
@@ -109,12 +96,13 @@ public class NotificationService {
                 new NotificationInfo(
                     notification.getId(),
                     notification.getResourceId(),
-                    notification.getContent().length() > lengthLimit ?
-                        notification.getContent().substring(0, lengthLimit) + "\""
-                        : notification.getContent() + "\"",
+                    notification.getNotificationType().getName(),
+                    notification.getContent().length() > CONTENT_LENGTH_LIMIT ?
+                        notification.getContent().substring(0, CONTENT_LENGTH_LIMIT)
+                        : notification.getContent(),
                     calculateTime(notification.getCreatedAt(), 4),
                     notification.isState(),
-                    notification.getType()
+                    notification.getNotificationType()
                 )
             );
         }

--- a/src/main/java/com/example/mssaem_backend/domain/notification/NotificationType.java
+++ b/src/main/java/com/example/mssaem_backend/domain/notification/NotificationType.java
@@ -2,7 +2,7 @@ package com.example.mssaem_backend.domain.notification;
 
 import lombok.Getter;
 
-public enum TypeEnum {
+public enum NotificationType {
     BOARD_COMMENT("내 게시물에 댓글이 달렸어요."),
     HOT_BOARD("내 게시글이 HOT한 게시글이 되었어요."),
 
@@ -11,12 +11,13 @@ public enum TypeEnum {
     HOT_DISCUSSION("내 토론이 HOT한 토론이 되었어요."),
     DISCUSSION_REPLY_OF_COMMENT("내 댓글에 대댓글이 달렸어요."),
     HOT_TEACHER("내가 인기 M쌤이 되었어요."),
-    CHAT("채팅을 시작했어요.");
+    CHAT("새로운 채팅이 시작됐어요."),
+    NEW_BADGE("새로운 칭호를 획득했어요");
 
     @Getter
     private final String name;
 
-    TypeEnum(String name) {
+    NotificationType(String name) {
         this.name = name;
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/notification/NotificationType.java
+++ b/src/main/java/com/example/mssaem_backend/domain/notification/NotificationType.java
@@ -12,7 +12,7 @@ public enum NotificationType {
     DISCUSSION_REPLY_OF_COMMENT("내 댓글에 대댓글이 달렸어요."),
     HOT_TEACHER("내가 인기 M쌤이 되었어요."),
     CHAT("새로운 채팅이 시작됐어요."),
-    NEW_BADGE("새로운 칭호를 획득했어요");
+    BADGE("새로운 칭호를 획득했어요");
 
     @Getter
     private final String name;

--- a/src/main/java/com/example/mssaem_backend/domain/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/com/example/mssaem_backend/domain/notification/dto/NotificationResponseDto.java
@@ -1,6 +1,6 @@
 package com.example.mssaem_backend.domain.notification.dto;
 
-import com.example.mssaem_backend.domain.notification.TypeEnum;
+import com.example.mssaem_backend.domain.notification.NotificationType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,10 +14,11 @@ public class NotificationResponseDto {
 
         private Long id; // 알림 id
         private Long resourceId; // 알림 대상 id
+        private String notificationTypeContent; // 알림 타입별 멘트
         private String content; // 알림 내용
         private String createdAt; // 오늘 알림 : 오전/오후 시간, 오늘 이전 알림 : 0월 0일
         private boolean state; // true : 읽음, false : 안 읽음
-        private TypeEnum type; // 알림의 타입
+        private NotificationType notificationType; // 알림의 타입
     }
 
 }

--- a/src/main/java/com/example/mssaem_backend/global/common/CommentService.java
+++ b/src/main/java/com/example/mssaem_backend/global/common/CommentService.java
@@ -16,7 +16,7 @@ import com.example.mssaem_backend.domain.discussioncommentlike.DiscussionComment
 import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.domain.member.dto.MemberResponseDto.MemberSimpleInfo;
 import com.example.mssaem_backend.domain.notification.NotificationService;
-import com.example.mssaem_backend.domain.notification.TypeEnum;
+import com.example.mssaem_backend.domain.notification.NotificationType;
 import com.example.mssaem_backend.global.common.dto.CommentDto.GetCommentsByMemberRes;
 import com.example.mssaem_backend.global.common.dto.CommentDto.GetCommentsRes;
 import com.example.mssaem_backend.global.common.dto.CommentDto.PostCommentReq;
@@ -184,12 +184,12 @@ public class CommentService {
                 //일반 댓글인 경우
                 if (!isMatch(board.getMember(), member)) {
                     notificationService.createNotification(objectId, content,
-                        TypeEnum.BOARD_COMMENT, board.getMember());
+                        NotificationType.BOARD_COMMENT, board.getMember());
                 }
                 //대댓글인 경우
                 if (isReply && !isMatch(parentComment.getMember(), member)) {
                     notificationService.createNotification(objectId, content,
-                        TypeEnum.BOARD_REPLY_OF_COMMENT, board.getMember());
+                        NotificationType.BOARD_REPLY_OF_COMMENT, board.getMember());
                 }
             }
             case DISCUSSION -> {
@@ -212,12 +212,12 @@ public class CommentService {
                 //일반 댓글인 경우
                 if (!isMatch(discussion.getMember(), member)) {
                     notificationService.createNotification(objectId, content,
-                        TypeEnum.DISCUSSION_COMMENT, discussion.getMember());
+                        NotificationType.DISCUSSION_COMMENT, discussion.getMember());
                 }
                 //대댓글인 경우
                 if (isReply && !isMatch(parentComment.getMember(), member)) {
                     notificationService.createNotification(objectId, content,
-                        TypeEnum.DISCUSSION_REPLY_OF_COMMENT, discussion.getMember());
+                        NotificationType.DISCUSSION_REPLY_OF_COMMENT, discussion.getMember());
                 }
             }
         }


### PR DESCRIPTION
## 요약

- 알림 응답 형식 수정

## 상세 내용
### NotificationType
- 원래 TypeEnum이었던 클래스명을 NotificationType으로 변경 
### NotificationService
- 새로운 채팅이 시작되면 고정 멘트 앞에 채팅 참가자의 닉네임을 넣어주던 것을 제외
   이유 : 칭호 획득시 알림을 보내줄건데 알림 내용을 한번에 보내기보단 얻은 칭호 이름은 따로 보내주기로 했는데 원래 로직상으로는 content에 모든 알림 내용이 다 들어가 있어서 분리를 해주려다보니 채팅 알림 메시지가 문제라 형식을 아예 바꿨습니다! 상대방의 닉네임을 제외해 알림 등록 메소드가 채팅용과 그 외로 나눠지던 것을 하나로 합칠 수 있게 되었어요!

## 질문 및 이외 사항

- 

## 이슈 번호

- #135