### PR TITLE
칭호 추가 API 구현

### DIFF
--- a/src/main/java/com/example/mssaem_backend/domain/badge/Badge.java
+++ b/src/main/java/com/example/mssaem_backend/domain/badge/Badge.java
@@ -2,8 +2,9 @@ package com.example.mssaem_backend.domain.badge;
 
 import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.global.common.BaseTimeEntity;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -23,11 +24,11 @@ public class Badge extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "badge_id")
     private Long id;
 
     @NotNull
-    private String name;
+    @Enumerated(EnumType.STRING)
+    private BadgeEnum badgeEnum;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
@@ -40,5 +41,11 @@ public class Badge extends BaseTimeEntity {
 
     public void changeStateFalse() {
         this.state = false;
+    }
+
+    public Badge(BadgeEnum badgeEnum, Member member, boolean state){
+        this.badgeEnum = badgeEnum;
+        this.member = member;
+        this.state = state;
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/badge/BadgeEnum.java
+++ b/src/main/java/com/example/mssaem_backend/domain/badge/BadgeEnum.java
@@ -1,0 +1,28 @@
+package com.example.mssaem_backend.domain.badge;
+
+import lombok.Getter;
+
+@Getter
+public enum BadgeEnum {
+    MBTIRANO("엠비티라노", "화끈해요", 10, ""),
+    MBTADULT("엠비티어른", "유익해요", 10, ""),
+    MBTMI("MBTMI", "성의있어요", 10, ""),
+    FUNFUN("FUNFUN", "재밌어요", 10, "");
+
+    private final String name;
+    private final String evaluation;
+    private final int standard;
+    private final String url;
+
+    public int getStandard(){
+        return standard;
+    }
+
+    BadgeEnum(String name, String evaluation, int standard, String url) {
+        this.name = name;
+        this.evaluation = evaluation;
+        this.standard = standard;
+        this.url = url;
+    }
+
+}

--- a/src/main/java/com/example/mssaem_backend/domain/badge/BadgeRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/badge/BadgeRepository.java
@@ -10,14 +10,16 @@ import org.springframework.data.repository.query.Param;
 
 public interface BadgeRepository extends JpaRepository<Badge, Long> {
 
-    @Query("SELECT b.name FROM Badge b WHERE b.member = :member AND b.state = true")
-    Optional<String> findNameMemberAndStateTrue(@Param("member") Member member);
+    @Query("SELECT b.badgeEnum FROM Badge b WHERE b.member = :member AND b.state = true")
+    Optional<BadgeEnum> findNameMemberAndStateTrue(@Param("member") Member member);
 
-    @Query("SELECT b.name FROM Badge b WHERE b.id = :id AND b.member = :member AND b.state = false")
-    Optional<String> findNameByIdAndMember(@Param("id") Long id, @Param("member") Member member);
+    @Query("SELECT b.badgeEnum FROM Badge b WHERE b.id = :id AND b.member = :member AND b.state = false")
+    Optional<BadgeEnum> findNameByIdAndMember(@Param("id") Long id, @Param("member") Member member);
 
     Optional<List<Badge>> findAllByMember(@Param("member") Member member);
 
     Optional<Badge> findByMemberAndStateTrue(Member member);
     Optional<Badge> findByIdAndMember(Long id, Member member);
+
+    boolean existsByMemberAndStateIsTrue(Member member);
 }

--- a/src/main/java/com/example/mssaem_backend/domain/badge/BadgeService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/badge/BadgeService.java
@@ -1,20 +1,16 @@
 package com.example.mssaem_backend.domain.badge;
 
-import com.example.mssaem_backend.domain.badge.dto.BadgeResponse;
-import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.domain.badge.dto.BadgeResponse.BadgeInfo;
-import com.example.mssaem_backend.domain.member.MemberRepository;
-import com.example.mssaem_backend.domain.member.MemberService;
+import com.example.mssaem_backend.domain.member.Member;
 import com.example.mssaem_backend.global.config.exception.BaseException;
 import com.example.mssaem_backend.global.config.exception.errorCode.BadgeErrorCode;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -24,14 +20,14 @@ public class BadgeService {
 
     //멤버의 대표 뱃지 가져오기
     public String findRepresentativeBadgeByMember(Member member) {
-        return badgeRepository.findNameMemberAndStateTrue(member).orElse(null);
+        return badgeRepository.findNameMemberAndStateTrue(member).orElse(null).getName();
     }
 
     public List<BadgeInfo> findAllBadge(Member member) {
         List<Badge> badges = badgeRepository.findAllByMember(member).orElse(null);
         List<BadgeInfo> result = new ArrayList<>();
         if (badges != null) {
-            badges.forEach(badge -> result.add(new BadgeInfo(badge.getId(), badge.getName(), badge.isState())));
+            badges.forEach(badge -> result.add(new BadgeInfo(badge.getId(), badge.getBadgeEnum().getName(), badge.isState())));
         }
         return result;
     }
@@ -53,8 +49,13 @@ public class BadgeService {
             }
             // 새로운 뱃지를 true 로 변경
             newBadge.changeStateTrue();
-            return newBadge.getName();
+            return newBadge.getBadgeEnum().getName();
         }
         return null;
     }
+
+    public void insertBadge(Badge badge){
+        badgeRepository.save(badge);
+    }
+    public boolean existBadgeStateTrue(Member member){ return badgeRepository.existsByMemberAndStateIsTrue(member);}
 }

--- a/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/board/BoardService.java
@@ -4,7 +4,6 @@ import static com.example.mssaem_backend.global.common.CheckWriter.isMatch;
 import static com.example.mssaem_backend.global.common.CheckWriter.match;
 import static com.example.mssaem_backend.global.common.Time.calculateTime;
 
-import com.example.mssaem_backend.domain.badge.BadgeRepository;
 import com.example.mssaem_backend.domain.board.dto.BoardRequestDto.PatchBoardReq;
 import com.example.mssaem_backend.domain.board.dto.BoardRequestDto.PostBoardReq;
 import com.example.mssaem_backend.domain.board.dto.BoardResponseDto.BoardHistory;
@@ -46,7 +45,6 @@ public class BoardService {
     private final BoardImageService boardImageService;
     private final LikeRepository likeRepository;
     private final BoardCommentRepository boardCommentRepository;
-    private final BadgeRepository badgeRepository;
     private final WorryBoardRepository worryBoardRepository;
     private final CommentService commentService;
     private final DiscussionService discussionService;
@@ -255,7 +253,7 @@ public class BoardService {
                     board.getMember().getId(),
                     board.getMember().getNickName(),
                     board.getMember().getDetailMbti(),
-                    badgeRepository.findNameMemberAndStateTrue(board.getMember()).orElse(null),
+                    board.getMember().getBadgeName(),
                     board.getMember().getProfileImageUrl()
                 )
             )

--- a/src/main/java/com/example/mssaem_backend/domain/chatparticipate/ChatParticipateRepository.java
+++ b/src/main/java/com/example/mssaem_backend/domain/chatparticipate/ChatParticipateRepository.java
@@ -4,6 +4,7 @@ import com.example.mssaem_backend.domain.chatroom.ChatRoom;
 import com.example.mssaem_backend.domain.member.Member;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -21,4 +22,11 @@ public interface ChatParticipateRepository extends JpaRepository<ChatParticipate
     ChatParticipate findByChatRoom(ChatRoom chatRoom);
 
     Integer countByChatRoomId(Long chatRoomId);
+
+    @Modifying
+    void deleteAllByChatRoom(ChatRoom chatRoom);
+
+    @Query("select cp.member from ChatParticipate cp where cp.member <> :member and cp.chatRoom = :chatroom")
+    Member findByMemberAndChatRoom(@Param("member") Member member,
+        @Param("chatroom") ChatRoom chatroom);
 }

--- a/src/main/java/com/example/mssaem_backend/domain/chatparticipate/ChatParticipateService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/chatparticipate/ChatParticipateService.java
@@ -99,13 +99,16 @@ public class ChatParticipateService {
     }
 
     @Transactional
-    public void deleteChatParticipate(String sessionId) {
-        ChatParticipate chatParticipate = chatParticipateRepository.findBySessionId(sessionId);
-        chatParticipateRepository.delete(chatParticipate);
+    public void deleteAllChatParticipateByChatRoom(ChatRoom chatRoom) {
+        chatParticipateRepository.deleteAllByChatRoom(chatRoom);
     }
 
     public Integer countChatParticipate(Long roomId) {
         return chatParticipateRepository.countByChatRoomId(roomId);
+    }
+
+    public Member getPartnerByChatRoomAndMember(Member member, ChatRoom chatRoom){
+        return chatParticipateRepository.findByMemberAndChatRoom(member, chatRoom);
     }
 
 }

--- a/src/main/java/com/example/mssaem_backend/domain/chatroom/ChatRoomService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/chatroom/ChatRoomService.java
@@ -4,7 +4,7 @@ import static com.example.mssaem_backend.global.config.exception.errorCode.ChatR
 import static com.example.mssaem_backend.global.config.exception.errorCode.WorryBoardErrorCode.EMPTY_WORRY_BOARD;
 
 import com.example.mssaem_backend.domain.chatmessage.ChatMessageService;
-import com.example.mssaem_backend.domain.chatparticipate.ChatParticipateRepository;
+import com.example.mssaem_backend.domain.chatparticipate.ChatParticipateService;
 import com.example.mssaem_backend.domain.chatroom.dto.ChatRoomRequestDto.ChatInfo;
 import com.example.mssaem_backend.domain.chatroom.dto.ChatRoomResponseDto.ChatRoomRes;
 import com.example.mssaem_backend.domain.worryboard.WorryBoard;
@@ -23,7 +23,7 @@ public class ChatRoomService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageService chatMessageService;
     private final WorryBoardRepository worryBoardRepository;
-    private final ChatParticipateRepository chatParticipateRepository;
+    private final ChatParticipateService chatParticipateService;
 
     public ChatRoomRes createRoom(Long worryBoardId) {
         ChatRoom chatRoom = chatRoomCustomRepository.createChatRoom(worryBoardId);
@@ -49,6 +49,8 @@ public class ChatRoomService {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId).orElseThrow();
         // 모든 채팅 메시지 삭제
         chatMessageService.deleteAllChatMessage(chatRoom);
+        // 채팅 참여 삭제
+        chatParticipateService.deleteAllChatParticipateByChatRoom(chatRoom);
         // 채팅방 삭제
         chatRoomRepository.delete(chatRoom);
         return "채팅방 삭제 완료";
@@ -60,8 +62,13 @@ public class ChatRoomService {
         ChatRoom chatRoom = chatRoomRepository.findByWorryBoardId(worryBoardId)
             .orElseThrow(() -> new BaseException(EMPTY_CHATROOM));
 
-        Integer count = chatParticipateRepository.countByChatRoomId(chatRoom.getId());
+        Integer count = chatParticipateService.countChatParticipate(chatRoom.getId());
         if(count == 1) return true;
         else return false;
+    }
+
+    public ChatRoom selectChatRoomByWorryBoardId(Long worryBoardId){
+        return chatRoomRepository.findByWorryBoardId(worryBoardId)
+            .orElseThrow(() -> new BaseException(EMPTY_CHATROOM));
     }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/discussion/DiscussionService.java
@@ -3,7 +3,6 @@ package com.example.mssaem_backend.domain.discussion;
 import static com.example.mssaem_backend.global.common.CheckWriter.isMatch;
 import static com.example.mssaem_backend.global.common.CheckWriter.match;
 
-import com.example.mssaem_backend.domain.badge.BadgeRepository;
 import com.example.mssaem_backend.domain.discussion.dto.DiscussionRequestDto.DiscussionReq;
 import com.example.mssaem_backend.domain.discussion.dto.DiscussionResponseDto.DiscussionDetailInfo;
 import com.example.mssaem_backend.domain.discussion.dto.DiscussionResponseDto.DiscussionHistory;
@@ -47,7 +46,6 @@ public class DiscussionService {
     private final DiscussionOptionRepository discussionOptionRepository;
     private final DiscussionOptionSelectedRepository discussionOptionSelectedRepository;
     private final DiscussionCommentRepository discussionCommentRepository;
-    private final BadgeRepository badgeRepository;
     private final NotificationService notificationService;
     private final MemberRepository memberRepository;
     private final CommentService commentService;
@@ -119,8 +117,7 @@ public class DiscussionService {
                         discussion.getMember().getId(),
                         discussion.getMember().getNickName(),
                         discussion.getMember().getDetailMbti(),
-                        badgeRepository.findNameMemberAndStateTrue(discussion.getMember())
-                            .orElse(null),
+                        discussion.getMember().getBadgeName(),
                         discussion.getMember().getProfileImageUrl()
                     ),
                     selectedOptionIdx != -1

--- a/src/main/java/com/example/mssaem_backend/domain/evaluation/EvaluationService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/evaluation/EvaluationService.java
@@ -1,10 +1,17 @@
 package com.example.mssaem_backend.domain.evaluation;
 
+import com.example.mssaem_backend.domain.badge.Badge;
+import com.example.mssaem_backend.domain.badge.BadgeEnum;
+import com.example.mssaem_backend.domain.badge.BadgeService;
+import com.example.mssaem_backend.domain.chatparticipate.ChatParticipateService;
+import com.example.mssaem_backend.domain.chatroom.ChatRoom;
+import com.example.mssaem_backend.domain.chatroom.ChatRoomService;
 import com.example.mssaem_backend.domain.evaluation.dto.EvaluationRequestDto.EvaluationInfo;
 import com.example.mssaem_backend.domain.evaluation.dto.EvaluationResultDto.EvaluationCount;
 import com.example.mssaem_backend.domain.evaluation.dto.EvaluationResultDto.EvaluationResult;
 import com.example.mssaem_backend.domain.member.Member;
-import com.example.mssaem_backend.domain.member.MemberRepository;
+import com.example.mssaem_backend.domain.notification.NotificationService;
+import com.example.mssaem_backend.domain.notification.NotificationType;
 import com.example.mssaem_backend.domain.worryboard.WorryBoard;
 import com.example.mssaem_backend.domain.worryboard.WorryBoardRepository;
 import java.util.ArrayList;
@@ -19,72 +26,116 @@ import org.springframework.stereotype.Service;
 @Service
 public class EvaluationService {
 
-  private final MemberRepository memberRepository;
-  private final WorryBoardRepository worryBoardRepository;
-  private final EvaluationRepository evaluationRepository;
+    private final WorryBoardRepository worryBoardRepository;
+    private final EvaluationRepository evaluationRepository;
+    private final BadgeService badgeService;
+    private final NotificationService notificationService;
+    private final ChatParticipateService chatParticipateService;
+    private final ChatRoomService chatRoomService;
 
-  /**
-   * 평가 추가 하기
-   */
-  public String insertEvaluation(Member member,EvaluationInfo evaluationInfo) {
-    //현재 고민글 조회
-    WorryBoard worryBoard = worryBoardRepository.findById(evaluationInfo.getWorryBoardId())
-        .orElseThrow();
-    //평가 리스트 체크
-    String[] checks = new String[5];
-    Arrays.fill(checks, "0");
-    evaluationInfo.getEvaluations().forEach(e -> {
-      if (e.equals(EvaluationEnum.LIKE)) {
-        checks[0] = "1";
-      } else if (e.equals(EvaluationEnum.USEFUL)) {
-        checks[1] = "1";
-      } else if (e.equals(EvaluationEnum.FUN)) {
-        checks[2] = "1";
-      } else if (e.equals(EvaluationEnum.SINCERE)) {
-        checks[3] = "1";
-      } else if (e.equals(EvaluationEnum.HOT)) {
-        checks[4] = "1";
-      }
-    });
-    String result = Arrays.stream(checks).collect(Collectors.joining());
-    evaluationRepository.save(new Evaluation(worryBoard, member, result));
-    return "펑가 완료";
-  }
+    /**
+     * 평가 추가 하기
+     */
+    public String insertEvaluation(Member member, EvaluationInfo evaluationInfo) {
+        //현재 고민글 조회
+        WorryBoard worryBoard = worryBoardRepository.findById(evaluationInfo.getWorryBoardId())
+            .orElseThrow();
+        //상대 조회
+        ChatRoom chatRoom = chatRoomService.selectChatRoomByWorryBoardId(
+            evaluationInfo.getWorryBoardId());
+        Member partner = chatParticipateService.getPartnerByChatRoomAndMember(
+            member, chatRoom);
 
-  /**
-   * 평가 받은 사람의 평가 내용 조회
-   */
-  public EvaluationResult selectEvaluation(Member member, Long worryBoardId) {
-    //고민글 조회
-    WorryBoard worryBoard = worryBoardRepository.findById(worryBoardId)
-        .orElseThrow();
-    Evaluation evaluation = evaluationRepository.findByWorryBoardAndMember(worryBoard, member);
+        //평가 리스트 체크
+        String[] checks = new String[5];
+        Arrays.fill(checks, "0");
+        evaluationInfo.getEvaluations().forEach(e -> {
+            if (e.equals(EvaluationEnum.LIKE)) {
+                checks[0] = "1";
+            } else if (e.equals(EvaluationEnum.USEFUL)) {
+                checks[1] = "1";
+            } else if (e.equals(EvaluationEnum.FUN)) {
+                checks[2] = "1";
+            } else if (e.equals(EvaluationEnum.SINCERE)) {
+                checks[3] = "1";
+            } else if (e.equals(EvaluationEnum.HOT)) {
+                checks[4] = "1";
+            }
+        });
+        String result = Arrays.stream(checks).collect(Collectors.joining());
+        evaluationRepository.save(new Evaluation(worryBoard, partner, result));
 
-    //자신이 받은 평가 출력
-    List<EvaluationEnum> result = new ArrayList<>();
-    EvaluationEnum[] enums = EvaluationEnum.values();
-    for (int i = 0; i < evaluation.getEvaluationCode().length(); i++) {
-      if (evaluation.getEvaluationCode().charAt(i) == '1') {
-        result.add(enums[i]);
-      }
+        // Badge추가 및 알림 추가
+        insertBadgeAndNotification(partner);
+        return "펑가 완료";
     }
-    return new EvaluationResult(worryBoardId, result);
-  }
 
-  /**
-   * 자신의 평가 count
-   */
-  public EvaluationCount countEvaluation(Member member) {
-    List<Evaluation> evaluations = evaluationRepository.findAllByMember(member);
-    int[] result = new int[EvaluationEnum.values().length];
-    for (Evaluation e : evaluations) {
-      char[] temp = e.getEvaluationCode().toCharArray();
-      result[0] += temp[0] - '0';
-      result[1] += temp[1] - '0';
-      result[2] += temp[2] - '0';
-      result[3] += temp[3] - '0';
-      result[4] += temp[4] - '0';
+    /**
+     * Badge 추가 및 알림 추가
+     */
+    public void insertBadgeAndNotification(Member partner) {
+        EvaluationCount evaluationCount = countEvaluation(partner);
+        boolean check = true;
+        if (badgeService.existBadgeStateTrue(partner)) {
+            check = false;
+        }
+        if (evaluationCount.getFunCount() == BadgeEnum.FUNFUN.getStandard()) {
+            Badge badge = new Badge(BadgeEnum.FUNFUN, partner, check);
+            badgeService.insertBadge(badge);
+            notificationService.createNotification(badge.getId(), badge.getBadgeEnum().getName(),
+                NotificationType.BADGE, partner);
+        } else if (evaluationCount.getHotCount() == BadgeEnum.MBTIRANO.getStandard()) {
+            Badge badge = new Badge(BadgeEnum.MBTIRANO, partner, check);
+            badgeService.insertBadge(badge);
+            notificationService.createNotification(badge.getId(), badge.getBadgeEnum().getName(),
+                NotificationType.BADGE, partner);
+        } else if (evaluationCount.getUsefulCount() == BadgeEnum.MBTADULT.getStandard()) {
+            Badge badge = new Badge(BadgeEnum.MBTADULT, partner, check);
+            badgeService.insertBadge(badge);
+            notificationService.createNotification(badge.getId(), badge.getBadgeEnum().getName(),
+                NotificationType.BADGE, partner);
+        } else if (evaluationCount.getSincereCount() == BadgeEnum.MBTMI.getStandard()) {
+            Badge badge = new Badge(BadgeEnum.MBTMI, partner, check);
+            badgeService.insertBadge(badge);
+            notificationService.createNotification(badge.getId(), badge.getBadgeEnum().getName(),
+                NotificationType.BADGE, partner);
+        }
     }
-    return new EvaluationCount(result);
-  }
+
+    /**
+     * 평가 받은 사람의 평가 내용 조회
+     */
+    public EvaluationResult selectEvaluation(Member member, Long worryBoardId) {
+        //고민글 조회
+        WorryBoard worryBoard = worryBoardRepository.findById(worryBoardId)
+            .orElseThrow();
+        Evaluation evaluation = evaluationRepository.findByWorryBoardAndMember(worryBoard, member);
+
+        //자신이 받은 평가 출력
+        List<EvaluationEnum> result = new ArrayList<>();
+        EvaluationEnum[] enums = EvaluationEnum.values();
+        for (int i = 0; i < evaluation.getEvaluationCode().length(); i++) {
+            if (evaluation.getEvaluationCode().charAt(i) == '1') {
+                result.add(enums[i]);
+            }
+        }
+        return new EvaluationResult(worryBoardId, result);
+    }
+
+    /**
+     * 자신의 평가 count
+     */
+    public EvaluationCount countEvaluation(Member member) {
+        List<Evaluation> evaluations = evaluationRepository.findAllByMember(member);
+        int[] result = new int[EvaluationEnum.values().length];
+        for (Evaluation e : evaluations) {
+            char[] temp = e.getEvaluationCode().toCharArray();
+            result[0] += temp[0] - '0';
+            result[1] += temp[1] - '0';
+            result[2] += temp[2] - '0';
+            result[3] += temp[3] - '0';
+            result[4] += temp[4] - '0';
+        }
+        return new EvaluationCount(result);
+    }
 }

--- a/src/main/java/com/example/mssaem_backend/domain/member/MemberService.java
+++ b/src/main/java/com/example/mssaem_backend/domain/member/MemberService.java
@@ -128,7 +128,7 @@ public class MemberService {
                     solveMember.getId(),
                     solveMember.getNickName(),
                     solveMember.getDetailMbti(),
-                    badgeRepository.findNameMemberAndStateTrue(solveMember).orElse(null),
+                    solveMember.getBadgeName(),
                     solveMember.getProfileImageUrl(),
                     solveMember.getIntroduction()
                 )

--- a/src/main/java/com/example/mssaem_backend/global/config/websocket/StompHandler.java
+++ b/src/main/java/com/example/mssaem_backend/global/config/websocket/StompHandler.java
@@ -103,7 +103,6 @@ public class StompHandler implements ChannelInterceptor {
 
             // 채팅 참여 기록 삭제
             chatRoomCustomRepository.removeUserEnterInfo(sessionId);
-            chatParticipateService.deleteChatParticipate(sessionId);
             log.info("DISCONNECTED {}, {}", sessionId, chatInfo.getChatRoomId());
         }
         return message;


### PR DESCRIPTION
## 요약
- 받은 평가의 갯수가 조건에 부합하면 칭호가 추가됩니다. 

## 상세 내용
- 채팅방에 로그인한 멤와 상대(파트너)가 존재합니다. 채팅이 끝나면 평가를 해야합니다.
- 평가를 완료하면 평가를 하는 멤버(로그인한 멤버)가 평가를 당하는 멤버(파트너)에게 평가를 합니다.

### 평가 진행과정

1. 채팅방에 같이 있는 상대방을 조회합니다.
```
ChatRoom chatRoom = chatRoomService.selectChatRoomByWorryBoardId(evaluationInfo.getWorryBoardId());
Member partner = chatParticipateService.getPartnerByChatRoomAndMember(member, chatRoom);
```
2. 받은 평가 리스트를 체크해 partner에게 평가를 추가 합니다. 
3. insertBadgeAndNotification이라는 메소드를 실행합니다.
    - 이 메소드는 지금 까지 partner가 받은 평가의 갯수를 조사합니다.
    - 조건에 부합하면 칭호를 추가합니다.
    - 칭호가 추가할 경우 알림에도 추가합니다.
    - 이 때, 칭호를 처음 얻었으면 자동으로 대표 칭호로 선택됩니다.

## 질문 및 이외 사항
- 현재 알림 추가는 유리햄의 코드를 사용했습니다.
![image](https://github.com/Help-M-Ssaem/back-end/assets/49395754/e5467322-ec49-4bf3-8565-580b27970735)
알림 추가를 하면 content에는 칭호 이름, notification_type에는 BADGE가 들어갑니다. 이렇게 들어가면 성공한거가요?? 

## 이슈 번호
- close #232 
