### PR TITLE
대댓글 알림 중복 제거 

### DIFF
--- a/src/main/java/com/example/mssaem_backend/global/common/CommentService.java
+++ b/src/main/java/com/example/mssaem_backend/global/common/CommentService.java
@@ -181,16 +181,17 @@ public class CommentService {
                 boardCommentRepository.save(boardComment);
 
                 //board 알림
-                //일반 댓글인 경우
-                if (!isMatch(board.getMember(), member)) {
-                    notificationService.createNotification(objectId, content,
-                        NotificationType.BOARD_COMMENT, board.getMember());
-                }
                 //대댓글인 경우
                 if (isReply && !isMatch(parentComment.getMember(), member)) {
                     notificationService.createNotification(objectId, content,
                         NotificationType.BOARD_REPLY_OF_COMMENT, board.getMember());
                 }
+                //일반 댓글인 경우
+                else if (!isMatch(board.getMember(), member)) {
+                    notificationService.createNotification(objectId, content,
+                        NotificationType.BOARD_COMMENT, board.getMember());
+                }
+
             }
             case DISCUSSION -> {
                 Discussion discussion = discussionRepository.findByIdAndStateIsTrue(objectId)
@@ -209,16 +210,17 @@ public class CommentService {
                 discussionCommentRepository.save(discussionComment);
 
                 //discussion 알림
-                //일반 댓글인 경우
-                if (!isMatch(discussion.getMember(), member)) {
-                    notificationService.createNotification(objectId, content,
-                        NotificationType.DISCUSSION_COMMENT, discussion.getMember());
-                }
                 //대댓글인 경우
                 if (isReply && !isMatch(parentComment.getMember(), member)) {
                     notificationService.createNotification(objectId, content,
                         NotificationType.DISCUSSION_REPLY_OF_COMMENT, discussion.getMember());
                 }
+                //일반 댓글인 경우
+                else if (!isMatch(discussion.getMember(), member)) {
+                    notificationService.createNotification(objectId, content,
+                        NotificationType.DISCUSSION_COMMENT, discussion.getMember());
+                }
+
             }
         }
         return "댓글 작성에 성공";


### PR DESCRIPTION
## 요약

- A가 쓴 게시물에 달려 있는 A의 댓글에 B가 대댓글을 달면 A에게 새로운 댓글 알림과 새로운 대댓글 알림이 중복되어 보내짐 -> 이 경우엔 대댓글 알림만 등록

## 상세 내용
### CommentService
- 대댓글 알림을 if문에 넣고, 일반 댓글을 else if로 해서 대댓글일 경우엔 대댓글 알림만 전송

## 질문 및 이외 사항

- 

## 이슈 번호

- #245
